### PR TITLE
Update

### DIFF
--- a/acorn/run-acorn.mirror.PCAD.pl
+++ b/acorn/run-acorn.mirror.PCAD.pl
@@ -50,7 +50,7 @@ if (!@a) {
     $host=`hostname`;
     chomp $host;
     system("$acorn_exe -u $UDP_port -C $msids -e $filesize -nv > /dev/null &");
-    open MAIL, "|mailx -s acorn isobe\@head.cfa.harvard.edu swolk\@head.cfa.harvard.edu malgosia\@head.cfa.harvard.edu";
+    open MAIL, "|mailx -s acorn tisobe\@cfa.harvard.edu swolk\@cfa.harvard.edu msobolewska\@cfa.harvard.edu";
     print MAIL "$host acorn dead. restarting. \n\n"; # current version
     close MAIL;
     print "Acorn process not found: restarting\n";

--- a/acorn/run-acorn.mirror.SOH.pl
+++ b/acorn/run-acorn.mirror.SOH.pl
@@ -54,7 +54,7 @@ if (!@a) {
     $host=`hostname`;
     chomp $host;
     system("$acorn_exe -u $UDP_port -C $msids -e $filesize -nv > /dev/null &");
-    open MAIL, "|mailx -s acorn tisobe\@cfa.harvard.edu swolk\@head.cfa.harvard.edu malgosia\@head.cfa.harvard.edu";
+    open MAIL, "|mailx -s acorn tisobe\@cfa.harvard.edu swolk\@cfa.harvard.edu msobolewska\@cfa.harvard.edu";
     print MAIL "$host colossus-v acorn dead. restarting. \n\n"; # current version
     close MAIL;
     print "Acorn process not found: restarting\n";

--- a/acorn/run-acorn.mirror.pl
+++ b/acorn/run-acorn.mirror.pl
@@ -57,7 +57,7 @@ if (!@a) {
     $host=`hostname`;
     chomp $host;
     system("$acorn_exe -u $UDP_port -C $msids -e $filesize -nv > /dev/null &");
-    open  MAIL, "|mailx -s acorn isobe\@head.cfa.harvard.edu swolk\@head.cfa.harvard.edu malgosia\@head.cfa.harvard.edu";
+    open  MAIL, "|mailx -s acorn tisobe\@cfa.harvard.edu swolk\@cfa.harvard.edu msobolewska\@cfa.harvard.edu";
     print MAIL  "$host colossus-v acorn dead. restarting. \n\n"; # current version
     close MAIL;
     print "Acorn process not found: restarting\n";

--- a/acorn/run-acorn.primary.SOH.pl
+++ b/acorn/run-acorn.primary.SOH.pl
@@ -51,8 +51,7 @@ if (!@a) {
     $host=`hostname`;
     chomp $host;
     system("$acorn_exe -u $UDP_port -C $msids -e $filesize -nv > /dev/null &");
-    #TMP open MAIL, "|mailx -s acorn 6172573986\@mobile.mycingular.com brad\@head-cfa.harvard.edu";
-    open MAIL, "|mailx -s acorn isobe\@head.cfa.harvard.edu swolk\@head.cfa.harvard.edu malgosia\@head.cfa.harvard.edu";
+    open MAIL, "|mailx -s acorn tisobe\@cfa.harvard.edu swolk\@cfa.harvard.edu msobolewska\@cfa.harvard.edu";
     print MAIL "$host SOH acorn dead. restarting. \n\n"; # current version
     close MAIL;
     print "Acorn process not found: restarting\n";

--- a/acorn/run-acorn.primary.pl
+++ b/acorn/run-acorn.primary.pl
@@ -51,8 +51,7 @@ if (!@a) {
     $host=`hostname`;
     chomp $host;
     system("$acorn_exe -u $UDP_port -C $msids -e $filesize -nv > /dev/null &");
-    #TMP open MAIL, "|mailx -s acorn 6172573986\@mobile.mycingular.com brad\@head-cfa.harvard.edu";
-    open MAIL, "|mailx -s acorn isobe\@head.cfa.harvard.edu swolk\@head.cfa.harvard.edu malgosia\@head.cfa.harvard.edu";
+    open MAIL, "|mailx -s acorn tisobe\@cfa.harvard.edu swolk\@cfa.harvard.edu msobolewska\@cfa.harvard.edu";
     print MAIL "$host acorn dead. restarting. \n\n"; # current version
     close MAIL;
     print "Acorn process not found: restarting\n";

--- a/alerts_back_out.sh
+++ b/alerts_back_out.sh
@@ -8,7 +8,7 @@ git_dir=/home/malgosia/git/alerts_update
 swdir=/data/mta4/space_weather
 
 cd $git_dir
-git checkout update
+git checkout master
 
 cp -f $git_dir/space_weather/aceviolation_protons.csh $swdir/
 cp -f $git_dir/space_weather/ace_12h_viol.pl $swdir/

--- a/alerts_back_out.sh
+++ b/alerts_back_out.sh
@@ -10,36 +10,72 @@ swdir=/data/mta4/space_weather
 cd $git_dir
 git checkout master
 
+diff $git_dir/space_weather/aceviolation_protons.csh $swdir/
 cp -f $git_dir/space_weather/aceviolation_protons.csh $swdir/
+
+diff $git_dir/space_weather/ace_12h_viol.pl $swdir/
 cp -f $git_dir/space_weather/ace_12h_viol.pl $swdir/
+
+diff $git_dir/space_weather/G13_yellow_viol.pl $swdir/
 cp -f $git_dir/space_weather/G13_yellow_viol.pl $swdir/
+
+diff $git_dir/space_weather/goes_hrc_proxy_viol.pl $swdir/
 cp -f $git_dir/space_weather/goes_hrc_proxy_viol.pl $swdir/
+
+
+diff $git_dir/space_weather/G13_red_viol.pl $swdir/
 cp -f $git_dir/space_weather/G13_red_viol.pl $swdir/
+
+
+diff $git_dir/space_weather/ace_invalid_spec.csh $swdir/
 cp -f $git_dir/space_weather/ace_invalid_spec.csh $swdir/
+
+diff $git_dir/space_weather/aceviolation_protonsP3_P5.csh $swdir/
 cp -f $git_dir/space_weather/aceviolation_protonsP3_P5.csh $swdir/
+
+diff $git_dir/space_weather/aceviolation_protonsP6.csh $swdir/
 cp -f $git_dir/space_weather/aceviolation_protonsP6.csh $swdir/
+
+diff $git_dir/space_weather/G15_yellow_viol.pl $swdir/
 cp -f $git_dir/space_weather/G15_yellow_viol.pl $swdir/
+
+diff $git_dir/space_weather/G15_red_viol.pl $swdir/
 cp -f $git_dir/space_weather/G15_red_viol.pl $swdir/
 
 # Dumps monitor
 dumpdir=/data/mta/Script/Dumps/Dumps_mon
 
+diff $git_dir/dumps/dumps_mon_2.6.pl $dumpdir/
 cp -f $git_dir/dumps/dumps_mon_2.6.pl $dumpdir/
 
 # Snapshot
-snapdir_primary=/data/mta4/www/Snapshot
-snapdir_mirror=/data/mta_www/MIRROR/Snap/Scripts
+snapdir_primary=/data/mta4/www/
+snapdir_mirror=/data/mta_www/MIRROR/
 
-cp -f $git_dir/snapshot/tlogr_linux.pl $snapdir_primary/
-cp -f $git_dir/snapshot/check_state.pm $snapdir_primary/
-cp -f $git_dir/snapshot/check_state_alerts.pm $snapdir_primary/
-cp -f $git_dir/snapshot/check_state_noalerts.pm $snapdir_primary/
+diff $git_dir/snapshot/tlogr_linux.pl $snapdir_primary/Snapshot/
+cp -f $git_dir/snapshot/tlogr_linux.pl $snapdir_primary/Snapshot/
+
+diff $git_dir/snapshot/check_state.pm $snapdir_primary/Snapshot/
+cp -f $git_dir/snapshot/check_state.pm $snapdir_primary/Snapshot/
+
+diff $git_dir/snapshot/check_state_alerts.pm $snapdir_primary/Snapshot/
+cp -f $git_dir/snapshot/check_state_alerts.pm $snapdir_primary/Snapshot/
+
+diff $git_dir/snapshot/check_state_noalerts.pm $snapdir_primary/Snapshot/
+cp -f $git_dir/snapshot/check_state_noalerts.pm $snapdir_primary/Snapshot/
 
 # Acorn
-cp -f $git_dir/acorn/run_acorn.primary.pl $snapdir_primary/run-acorn.pl
-cp -f $git_dir/acorn/run_acorn.primary.SOH.pl $snapdir_primary/../SOH/run-acorn.pl
+diff $git_dir/acorn/run_acorn.primary.pl $snapdir_primary/Snapshot/run-acorn.pl
+cp -f $git_dir/acorn/run_acorn.primary.pl $snapdir_primary/Snapshot/run-acorn.pl
 
-cp -f $git_dir/acorn/run_acorn.mirror.pl $snapdir_mirror/run-acorn.pl
-cp -f $git_dir/acorn/run_acorn.mirror.SOH.pl $snapdir_mirror/../../SOH/Scripts/run-acorn.pl
-cp -f $git_dir/acorn/run_acorn.mirror.PCAD.pl $snapdir_mirror/../../SOH/Scripts/run-acorn-pcad.pl
+diff $git_dir/acorn/run_acorn.primary.SOH.pl $snapdir_primary/SOH/run-acorn.pl
+cp -f $git_dir/acorn/run_acorn.primary.SOH.pl $snapdir_primary/SOH/run-acorn.pl
 
+diff $git_dir/acorn/run_acorn.mirror.pl $snapdir_mirror/Snap/Scrips/run-acorn.pl
+cp -f $git_dir/acorn/run_acorn.mirror.pl $snapdir_mirror/Snap/Scripts/run-acorn.pl
+
+diff $git_dir/acorn/run_acorn.mirror.SOH.pl $snapdir_mirror/SOH/Scripts/run-acorn.pl
+cp -f $git_dir/acorn/run_acorn.mirror.SOH.pl $snapdir_mirror/SOH/Scripts/run-acorn.pl
+
+diff $git_dir/acorn/run_acorn.mirror.PCAD.pl $snapdir_mirror/SOH/Scripts/run-acorn-pcad.pl
+cp -f $git_dir/acorn/run_acorn.mirror.PCAD.pl $snapdir_mirror/SOH/Scripts/run-acorn-pcad.pl

--- a/alerts_back_out.sh
+++ b/alerts_back_out.sh
@@ -10,56 +10,56 @@ swdir=/data/mta4/space_weather
 cd $git_dir
 git checkout master
 
-diff $git_dir/space_weather/aceviolation_protons.csh $swdir/
+diff $git_dir/space_weather/aceviolation_protons.csh $swdir/aceviolation_protons.csh
 cp -f $git_dir/space_weather/aceviolation_protons.csh $swdir/
 
-diff $git_dir/space_weather/ace_12h_viol.pl $swdir/
+diff $git_dir/space_weather/ace_12h_viol.pl $swdir/ace_12h_viol.pl
 cp -f $git_dir/space_weather/ace_12h_viol.pl $swdir/
 
-diff $git_dir/space_weather/G13_yellow_viol.pl $swdir/
+diff $git_dir/space_weather/G13_yellow_viol.pl $swdir/G13_yellow_viol.pl
 cp -f $git_dir/space_weather/G13_yellow_viol.pl $swdir/
 
-diff $git_dir/space_weather/goes_hrc_proxy_viol.pl $swdir/
+diff $git_dir/space_weather/goes_hrc_proxy_viol.pl $swdir/goes_hrc_proxy_viol.pl
 cp -f $git_dir/space_weather/goes_hrc_proxy_viol.pl $swdir/
 
-diff $git_dir/space_weather/G13_red_viol.pl $swdir/
+diff $git_dir/space_weather/G13_red_viol.pl $swdir/G13_red_viol.pl
 cp -f $git_dir/space_weather/G13_red_viol.pl $swdir/
 
-diff $git_dir/space_weather/ace_invalid_spec.csh $swdir/
+diff $git_dir/space_weather/ace_invalid_spec.csh $swdir/ace_invalid_spec.csh
 cp -f $git_dir/space_weather/ace_invalid_spec.csh $swdir/
 
-diff $git_dir/space_weather/aceviolation_protonsP3_P5.csh $swdir/
+diff $git_dir/space_weather/aceviolation_protonsP3_P5.csh $swdir/aceviolation_protonsP3_P5.csh
 cp -f $git_dir/space_weather/aceviolation_protonsP3_P5.csh $swdir/
 
-diff $git_dir/space_weather/aceviolation_protonsP6.csh $swdir/
+diff $git_dir/space_weather/aceviolation_protonsP6.csh $swdir/aceviolation_protonsP6.csh
 cp -f $git_dir/space_weather/aceviolation_protonsP6.csh $swdir/
 
-diff $git_dir/space_weather/G15_yellow_viol.pl $swdir/
+diff $git_dir/space_weather/G15_yellow_viol.pl $swdir/G15_yellow_viol.pl
 cp -f $git_dir/space_weather/G15_yellow_viol.pl $swdir/
 
-diff $git_dir/space_weather/G15_red_viol.pl $swdir/
+diff $git_dir/space_weather/G15_red_viol.pl $swdir/G15_red_viol.pl
 cp -f $git_dir/space_weather/G15_red_viol.pl $swdir/
 
 # Dumps monitor
 dumpdir=/data/mta/Script/Dumps/Dumps_mon
 
-diff $git_dir/dumps/dumps_mon_2.6.pl $dumpdir/
+diff $git_dir/dumps/dumps_mon_2.6.pl $dumpdir/dumps_mon_2.6.pl
 cp -f $git_dir/dumps/dumps_mon_2.6.pl $dumpdir/
 
 # Snapshot
 snapdir_primary=/data/mta4/www/
 snapdir_mirror=/data/mta_www/MIRROR/
 
-diff $git_dir/snapshot/tlogr_linux.pl $snapdir_primary/Snapshot/
+diff $git_dir/snapshot/tlogr_linux.pl $snapdir_primary/Snapshot/tlogr_linux.pl
 cp -f $git_dir/snapshot/tlogr_linux.pl $snapdir_primary/Snapshot/
 
-diff $git_dir/snapshot/check_state.pm $snapdir_primary/Snapshot/
+diff $git_dir/snapshot/check_state.pm $snapdir_primary/Snapshot/check_state.pm
 cp -f $git_dir/snapshot/check_state.pm $snapdir_primary/Snapshot/
 
-diff $git_dir/snapshot/check_state_alerts.pm $snapdir_primary/Snapshot/
+diff $git_dir/snapshot/check_state_alerts.pm $snapdir_primary/Snapshot/check_state_alerts.pm
 cp -f $git_dir/snapshot/check_state_alerts.pm $snapdir_primary/Snapshot/
 
-diff $git_dir/snapshot/check_state_noalerts.pm $snapdir_primary/Snapshot/
+diff $git_dir/snapshot/check_state_noalerts.pm $snapdir_primary/Snapshot//check_state_noalerts.pm
 cp -f $git_dir/snapshot/check_state_noalerts.pm $snapdir_primary/Snapshot/
 
 # Acorn

--- a/alerts_back_out.sh
+++ b/alerts_back_out.sh
@@ -22,10 +22,8 @@ cp -f $git_dir/space_weather/G13_yellow_viol.pl $swdir/
 diff $git_dir/space_weather/goes_hrc_proxy_viol.pl $swdir/
 cp -f $git_dir/space_weather/goes_hrc_proxy_viol.pl $swdir/
 
-
 diff $git_dir/space_weather/G13_red_viol.pl $swdir/
 cp -f $git_dir/space_weather/G13_red_viol.pl $swdir/
-
 
 diff $git_dir/space_weather/ace_invalid_spec.csh $swdir/
 cp -f $git_dir/space_weather/ace_invalid_spec.csh $swdir/
@@ -65,17 +63,17 @@ diff $git_dir/snapshot/check_state_noalerts.pm $snapdir_primary/Snapshot/
 cp -f $git_dir/snapshot/check_state_noalerts.pm $snapdir_primary/Snapshot/
 
 # Acorn
-diff $git_dir/acorn/run_acorn.primary.pl $snapdir_primary/Snapshot/run-acorn.pl
-cp -f $git_dir/acorn/run_acorn.primary.pl $snapdir_primary/Snapshot/run-acorn.pl
+diff $git_dir/acorn/run-acorn.primary.pl $snapdir_primary/Snapshot/run-acorn.pl
+cp -f $git_dir/acorn/run-acorn.primary.pl $snapdir_primary/Snapshot/run-acorn.pl
 
-diff $git_dir/acorn/run_acorn.primary.SOH.pl $snapdir_primary/SOH/run-acorn.pl
-cp -f $git_dir/acorn/run_acorn.primary.SOH.pl $snapdir_primary/SOH/run-acorn.pl
+diff $git_dir/acorn/run-acorn.primary.SOH.pl $snapdir_primary/SOH/run-acorn.pl
+cp -f $git_dir/acorn/run-acorn.primary.SOH.pl $snapdir_primary/SOH/run-acorn.pl
 
-diff $git_dir/acorn/run_acorn.mirror.pl $snapdir_mirror/Snap/Scrips/run-acorn.pl
-cp -f $git_dir/acorn/run_acorn.mirror.pl $snapdir_mirror/Snap/Scripts/run-acorn.pl
+diff $git_dir/acorn/run-acorn.mirror.pl $snapdir_mirror/Snap/Scrips/run-acorn.pl
+cp -f $git_dir/acorn/run-acorn.mirror.pl $snapdir_mirror/Snap/Scripts/run-acorn.pl
 
-diff $git_dir/acorn/run_acorn.mirror.SOH.pl $snapdir_mirror/SOH/Scripts/run-acorn.pl
-cp -f $git_dir/acorn/run_acorn.mirror.SOH.pl $snapdir_mirror/SOH/Scripts/run-acorn.pl
+diff $git_dir/acorn/run-acorn.mirror.SOH.pl $snapdir_mirror/SOH/Scripts/run-acorn.pl
+cp -f $git_dir/acorn/run-acorn.mirror.SOH.pl $snapdir_mirror/SOH/Scripts/run-acorn.pl
 
-diff $git_dir/acorn/run_acorn.mirror.PCAD.pl $snapdir_mirror/SOH/Scripts/run-acorn-pcad.pl
-cp -f $git_dir/acorn/run_acorn.mirror.PCAD.pl $snapdir_mirror/SOH/Scripts/run-acorn-pcad.pl
+diff $git_dir/acorn/run-acorn.mirror.PCAD.pl $snapdir_mirror/SOH/Scripts/run-acorn-pcad.pl
+cp -f $git_dir/acorn/run-acorn.mirror.PCAD.pl $snapdir_mirror/SOH/Scripts/run-acorn-pcad.pl

--- a/alerts_install.sh
+++ b/alerts_install.sh
@@ -10,56 +10,56 @@ swdir=/data/mta4/space_weather
 cd $git_dir
 git checkout update
 
-diff $git_dir/space_weather/aceviolation_protons.csh $swdir/
+diff $git_dir/space_weather/aceviolation_protons.csh $swdir/aceviolation_protons.csh
 cp -f $git_dir/space_weather/aceviolation_protons.csh $swdir/
 
-diff $git_dir/space_weather/ace_12h_viol.pl $swdir/
+diff $git_dir/space_weather/ace_12h_viol.pl $swdir/ace_12h_viol.pl
 cp -f $git_dir/space_weather/ace_12h_viol.pl $swdir/
 
-diff $git_dir/space_weather/G13_yellow_viol.pl $swdir/
+diff $git_dir/space_weather/G13_yellow_viol.pl $swdir/G13_yellow_viol.pl
 cp -f $git_dir/space_weather/G13_yellow_viol.pl $swdir/
 
-diff $git_dir/space_weather/goes_hrc_proxy_viol.pl $swdir/
+diff $git_dir/space_weather/goes_hrc_proxy_viol.pl $swdir/goes_hrc_proxy_viol.pl
 cp -f $git_dir/space_weather/goes_hrc_proxy_viol.pl $swdir/
 
-diff $git_dir/space_weather/G13_red_viol.pl $swdir/
+diff $git_dir/space_weather/G13_red_viol.pl $swdir/G13_red_viol.pl
 cp -f $git_dir/space_weather/G13_red_viol.pl $swdir/
 
-diff $git_dir/space_weather/ace_invalid_spec.csh $swdir/
+diff $git_dir/space_weather/ace_invalid_spec.csh $swdir/ace_invalid_spec.csh
 cp -f $git_dir/space_weather/ace_invalid_spec.csh $swdir/
 
-diff $git_dir/space_weather/aceviolation_protonsP3_P5.csh $swdir/
+diff $git_dir/space_weather/aceviolation_protonsP3_P5.csh $swdir/aceviolation_protonsP3_P5.csh
 cp -f $git_dir/space_weather/aceviolation_protonsP3_P5.csh $swdir/
 
-diff $git_dir/space_weather/aceviolation_protonsP6.csh $swdir/
+diff $git_dir/space_weather/aceviolation_protonsP6.csh $swdir/aceviolation_protonsP6.csh
 cp -f $git_dir/space_weather/aceviolation_protonsP6.csh $swdir/
 
-diff $git_dir/space_weather/G15_yellow_viol.pl $swdir/
+diff $git_dir/space_weather/G15_yellow_viol.pl $swdir/G15_yellow_viol.pl
 cp -f $git_dir/space_weather/G15_yellow_viol.pl $swdir/
 
-diff $git_dir/space_weather/G15_red_viol.pl $swdir/
+diff $git_dir/space_weather/G15_red_viol.pl $swdir/G15_red_viol.pl
 cp -f $git_dir/space_weather/G15_red_viol.pl $swdir/
 
 # Dumps monitor
 dumpdir=/data/mta/Script/Dumps/Dumps_mon
 
-diff $git_dir/dumps/dumps_mon_2.6.pl $dumpdir/
+diff $git_dir/dumps/dumps_mon_2.6.pl $dumpdir/dumps_mon_2.6.pl
 cp -f $git_dir/dumps/dumps_mon_2.6.pl $dumpdir/
 
 # Snapshot
 snapdir_primary=/data/mta4/www/
 snapdir_mirror=/data/mta_www/MIRROR/
 
-diff $git_dir/snapshot/tlogr_linux.pl $snapdir_primary/Snapshot/
+diff $git_dir/snapshot/tlogr_linux.pl $snapdir_primary/Snapshot/tlogr_linux.pl
 cp -f $git_dir/snapshot/tlogr_linux.pl $snapdir_primary/Snapshot/
 
-diff $git_dir/snapshot/check_state.pm $snapdir_primary/Snapshot/
+diff $git_dir/snapshot/check_state.pm $snapdir_primary/Snapshot/check_state.pm
 cp -f $git_dir/snapshot/check_state.pm $snapdir_primary/Snapshot/
 
-diff $git_dir/snapshot/check_state_alerts.pm $snapdir_primary/Snapshot/
+diff $git_dir/snapshot/check_state_alerts.pm $snapdir_primary/Snapshot/check_state_alerts.pm
 cp -f $git_dir/snapshot/check_state_alerts.pm $snapdir_primary/Snapshot/
 
-diff $git_dir/snapshot/check_state_noalerts.pm $snapdir_primary/Snapshot/
+diff $git_dir/snapshot/check_state_noalerts.pm $snapdir_primary/Snapshot//check_state_noalerts.pm
 cp -f $git_dir/snapshot/check_state_noalerts.pm $snapdir_primary/Snapshot/
 
 # Acorn

--- a/alerts_install.sh
+++ b/alerts_install.sh
@@ -10,36 +10,72 @@ swdir=/data/mta4/space_weather
 cd $git_dir
 git checkout update
 
+diff $git_dir/space_weather/aceviolation_protons.csh $swdir/
 cp -f $git_dir/space_weather/aceviolation_protons.csh $swdir/
+
+diff $git_dir/space_weather/ace_12h_viol.pl $swdir/
 cp -f $git_dir/space_weather/ace_12h_viol.pl $swdir/
+
+diff $git_dir/space_weather/G13_yellow_viol.pl $swdir/
 cp -f $git_dir/space_weather/G13_yellow_viol.pl $swdir/
+
+diff $git_dir/space_weather/goes_hrc_proxy_viol.pl $swdir/
 cp -f $git_dir/space_weather/goes_hrc_proxy_viol.pl $swdir/
+
+
+diff $git_dir/space_weather/G13_red_viol.pl $swdir/
 cp -f $git_dir/space_weather/G13_red_viol.pl $swdir/
+
+
+diff $git_dir/space_weather/ace_invalid_spec.csh $swdir/
 cp -f $git_dir/space_weather/ace_invalid_spec.csh $swdir/
+
+diff $git_dir/space_weather/aceviolation_protonsP3_P5.csh $swdir/
 cp -f $git_dir/space_weather/aceviolation_protonsP3_P5.csh $swdir/
+
+diff $git_dir/space_weather/aceviolation_protonsP6.csh $swdir/
 cp -f $git_dir/space_weather/aceviolation_protonsP6.csh $swdir/
+
+diff $git_dir/space_weather/G15_yellow_viol.pl $swdir/
 cp -f $git_dir/space_weather/G15_yellow_viol.pl $swdir/
+
+diff $git_dir/space_weather/G15_red_viol.pl $swdir/
 cp -f $git_dir/space_weather/G15_red_viol.pl $swdir/
 
 # Dumps monitor
 dumpdir=/data/mta/Script/Dumps/Dumps_mon
 
+diff $git_dir/dumps/dumps_mon_2.6.pl $dumpdir/
 cp -f $git_dir/dumps/dumps_mon_2.6.pl $dumpdir/
 
 # Snapshot
-snapdir_primary=/data/mta4/www/Snapshot
-snapdir_mirror=/data/mta_www/MIRROR/Snap/Scripts
+snapdir_primary=/data/mta4/www/
+snapdir_mirror=/data/mta_www/MIRROR/
 
-cp -f $git_dir/snapshot/tlogr_linux.pl $snapdir_primary/
-cp -f $git_dir/snapshot/check_state.pm $snapdir_primary/
-cp -f $git_dir/snapshot/check_state_alerts.pm $snapdir_primary/
-cp -f $git_dir/snapshot/check_state_noalerts.pm $snapdir_primary/
+diff $git_dir/snapshot/tlogr_linux.pl $snapdir_primary/Snapshot/
+cp -f $git_dir/snapshot/tlogr_linux.pl $snapdir_primary/Snapshot/
+
+diff $git_dir/snapshot/check_state.pm $snapdir_primary/Snapshot/
+cp -f $git_dir/snapshot/check_state.pm $snapdir_primary/Snapshot/
+
+diff $git_dir/snapshot/check_state_alerts.pm $snapdir_primary/Snapshot/
+cp -f $git_dir/snapshot/check_state_alerts.pm $snapdir_primary/Snapshot/
+
+diff $git_dir/snapshot/check_state_noalerts.pm $snapdir_primary/Snapshot/
+cp -f $git_dir/snapshot/check_state_noalerts.pm $snapdir_primary/Snapshot/
 
 # Acorn
-cp -f $git_dir/acorn/run_acorn.primary.pl $snapdir_primary/run-acorn.pl
-cp -f $git_dir/acorn/run_acorn.primary.SOH.pl $snapdir_primary/../SOH/run-acorn.pl
+diff $git_dir/acorn/run_acorn.primary.pl $snapdir_primary/Snapshot/run-acorn.pl
+cp -f $git_dir/acorn/run_acorn.primary.pl $snapdir_primary/Snapshot/run-acorn.pl
 
-cp -f $git_dir/acorn/run_acorn.mirror.pl $snapdir_mirror/run-acorn.pl
-cp -f $git_dir/acorn/run_acorn.mirror.SOH.pl $snapdir_mirror/../../SOH/Scripts/run-acorn.pl
-cp -f $git_dir/acorn/run_acorn.mirror.PCAD.pl $snapdir_mirror/../../SOH/Scripts/run-acorn-pcad.pl
+diff $git_dir/acorn/run_acorn.primary.SOH.pl $snapdir_primary/SOH/run-acorn.pl
+cp -f $git_dir/acorn/run_acorn.primary.SOH.pl $snapdir_primary/SOH/run-acorn.pl
 
+diff $git_dir/acorn/run_acorn.mirror.pl $snapdir_mirror/Snap/Scrips/run-acorn.pl
+cp -f $git_dir/acorn/run_acorn.mirror.pl $snapdir_mirror/Snap/Scripts/run-acorn.pl
+
+diff $git_dir/acorn/run_acorn.mirror.SOH.pl $snapdir_mirror/SOH/Scripts/run-acorn.pl
+cp -f $git_dir/acorn/run_acorn.mirror.SOH.pl $snapdir_mirror/SOH/Scripts/run-acorn.pl
+
+diff $git_dir/acorn/run_acorn.mirror.PCAD.pl $snapdir_mirror/SOH/Scripts/run-acorn-pcad.pl
+cp -f $git_dir/acorn/run_acorn.mirror.PCAD.pl $snapdir_mirror/SOH/Scripts/run-acorn-pcad.pl

--- a/alerts_install.sh
+++ b/alerts_install.sh
@@ -1,0 +1,42 @@
+#! /bin/sh
+# Run on r2d2-v because dump monitor and acorn scripts are on /data/mta
+# Run as user mta
+
+git_dir=/home/malgosia/git/alerts_update
+
+# Space weather
+swdir=/data/mta4/space_weather
+
+cp -f $git_dir/space_weather/aceviolation_protons.csh $swdir/
+cp -f $git_dir/space_weather/ace_12h_viol.pl $swdir/
+cp -f $git_dir/space_weather/G13_yellow_viol.pl $swdir/
+cp -f $git_dir/space_weather/goes_hrc_proxy_viol.pl $swdir/
+cp -f $git_dir/space_weather/G13_red_viol.pl $swdir/
+cp -f $git_dir/space_weather/ace_invalid_spec.csh $swdir/
+cp -f $git_dir/space_weather/aceviolation_protonsP3_P5.csh $swdir/
+cp -f $git_dir/space_weather/aceviolation_protonsP6.csh $swdir/
+cp -f $git_dir/space_weather/G15_yellow_viol.pl $swdir/
+cp -f $git_dir/space_weather/G15_red_viol.pl $swdir/
+
+# Dumps monitor
+dumpdir=/data/mta/Script/Dumps/Dumps_mon
+
+cp -f $git_dir/dumps/dumps_mon_2.6.pl $dumpdir/
+
+# Snapshot
+snapdir_primary=/data/mta4/www/Snapshot
+snapdir_mirror=/data/mta_www/MIRROR/Snap/Scripts
+
+cp -f $git_dir/snapshot/tlogr_linux.pl $snapdir_primary/
+cp -f $git_dir/snapshot/check_state.pm $snapdir_primary/
+cp -f $git_dir/snapshot/check_state_alerts.pm $snapdir_primary/
+cp -f $git_dir/snapshot/check_state_noalerts.pm $snapdir_primary/
+
+# Acorn
+cp -f $git_dir/acorn/run_acorn.primary.pl $snapdir_primary/run-acorn.pl
+cp -f $git_dir/acorn/run_acorn.primary.SOH.pl $snapdir_primary/../SOH/run-acorn.pl
+
+cp -f $git_dir/acorn_mirror/run_acorn.mirror.pl $snapdir_mirror/run-acorn.pl
+cp -f $git_dir/acorn/run_acorn.mirror.SOH.pl $snapdir_mirror/../../SOH/Scripts/run-acorn.pl
+cp -f $git_dir/acorn/run_acorn.mirror.PCAD.pl $snapdir_mirror/../../SOH/Scripts/run-acorn-pcad.pl
+

--- a/alerts_install.sh
+++ b/alerts_install.sh
@@ -22,10 +22,8 @@ cp -f $git_dir/space_weather/G13_yellow_viol.pl $swdir/
 diff $git_dir/space_weather/goes_hrc_proxy_viol.pl $swdir/
 cp -f $git_dir/space_weather/goes_hrc_proxy_viol.pl $swdir/
 
-
 diff $git_dir/space_weather/G13_red_viol.pl $swdir/
 cp -f $git_dir/space_weather/G13_red_viol.pl $swdir/
-
 
 diff $git_dir/space_weather/ace_invalid_spec.csh $swdir/
 cp -f $git_dir/space_weather/ace_invalid_spec.csh $swdir/
@@ -65,17 +63,17 @@ diff $git_dir/snapshot/check_state_noalerts.pm $snapdir_primary/Snapshot/
 cp -f $git_dir/snapshot/check_state_noalerts.pm $snapdir_primary/Snapshot/
 
 # Acorn
-diff $git_dir/acorn/run_acorn.primary.pl $snapdir_primary/Snapshot/run-acorn.pl
-cp -f $git_dir/acorn/run_acorn.primary.pl $snapdir_primary/Snapshot/run-acorn.pl
+diff $git_dir/acorn/run-acorn.primary.pl $snapdir_primary/Snapshot/run-acorn.pl
+cp -f $git_dir/acorn/run-acorn.primary.pl $snapdir_primary/Snapshot/run-acorn.pl
 
-diff $git_dir/acorn/run_acorn.primary.SOH.pl $snapdir_primary/SOH/run-acorn.pl
-cp -f $git_dir/acorn/run_acorn.primary.SOH.pl $snapdir_primary/SOH/run-acorn.pl
+diff $git_dir/acorn/run-acorn.primary.SOH.pl $snapdir_primary/SOH/run-acorn.pl
+cp -f $git_dir/acorn/run-acorn.primary.SOH.pl $snapdir_primary/SOH/run-acorn.pl
 
-diff $git_dir/acorn/run_acorn.mirror.pl $snapdir_mirror/Snap/Scrips/run-acorn.pl
-cp -f $git_dir/acorn/run_acorn.mirror.pl $snapdir_mirror/Snap/Scripts/run-acorn.pl
+diff $git_dir/acorn/run-acorn.mirror.pl $snapdir_mirror/Snap/Scrips/run-acorn.pl
+cp -f $git_dir/acorn/run-acorn.mirror.pl $snapdir_mirror/Snap/Scripts/run-acorn.pl
 
-diff $git_dir/acorn/run_acorn.mirror.SOH.pl $snapdir_mirror/SOH/Scripts/run-acorn.pl
-cp -f $git_dir/acorn/run_acorn.mirror.SOH.pl $snapdir_mirror/SOH/Scripts/run-acorn.pl
+diff $git_dir/acorn/run-acorn.mirror.SOH.pl $snapdir_mirror/SOH/Scripts/run-acorn.pl
+cp -f $git_dir/acorn/run-acorn.mirror.SOH.pl $snapdir_mirror/SOH/Scripts/run-acorn.pl
 
-diff $git_dir/acorn/run_acorn.mirror.PCAD.pl $snapdir_mirror/SOH/Scripts/run-acorn-pcad.pl
-cp -f $git_dir/acorn/run_acorn.mirror.PCAD.pl $snapdir_mirror/SOH/Scripts/run-acorn-pcad.pl
+diff $git_dir/acorn/run-acorn.mirror.PCAD.pl $snapdir_mirror/SOH/Scripts/run-acorn-pcad.pl
+cp -f $git_dir/acorn/run-acorn.mirror.PCAD.pl $snapdir_mirror/SOH/Scripts/run-acorn-pcad.pl

--- a/dumps/dumps_mon_2.6.pl
+++ b/dumps/dumps_mon_2.6.pl
@@ -1584,7 +1584,7 @@ close REPORT;
 #  E-mail violations, if any
 # *******************************************************************
 if ( -s "testfile.out" ) {
-  open MAIL, "|mailx -s config_mon_2.6 swolk brad\@head.cfa.harvard.edu malgosia\@head.cfa.harvard.edu";
+  open MAIL, "|mailx -s config_mon_2.6 swolk\@cfa.harvard.edu msobolewska\@cfa.harvard.edu";
   print MAIL "config_mon_2.6 \n\n"; # current version
   if ( -s $dumpname ) {
     open DNAME, "<$dumpname";
@@ -1598,7 +1598,7 @@ if ( -s "testfile.out" ) {
   while (<REPORT>) {
     print MAIL $_;
   }
-  print MAIL "This message sent to swolk brad malgosia.\n";
+  print MAIL "This message sent to swolk malgosia.\n";
   close MAIL;
 }
 
@@ -1607,7 +1607,7 @@ my $lockfile = "./.dumps_mon_lock";
 my $safefile = "/home/mta/Snap/.scs107alert";  # lock created by snapshot
 if ( -s $outfile ) {
   if ( -s $lockfile || -s $safefile ) {  # already sent, don't send again
-    open MAIL, "|mailx -s config_mon_2.6 swolk brad\@head.cfa.harvard.edu malgosia\@head.cfa.harvard.edu";
+    open MAIL, "|mailx -s config_mon_2.6 swolk\@cfa.harvard.edu msobolewska\@cfa.harvard.edu";
     #open MAIL, "|more"; #debug
     print MAIL "config_mon_2.6 \n\n"; # current version
     if ( -s $dumpname ) {
@@ -1632,7 +1632,7 @@ if ( -s $outfile ) {
     ###test 12/06/11open MAIL, "|mailx -s config_mon sot_lead\@head.cfa.harvard.edu brad\@head.cfa.harvard.edu jnichols\@head.cfa.harvard.edu";
     #open MAIL, "|mailx -s config_mon sot_yellow_alert\@head.cfa.harvard.edu";
     #open MAIL, "|mail brad\@head.cfa.harvard.edu swolk\@head.cfa.harvard.edu";
-    open MAIL, "|mailx -s config_mon_2.6 swolk brad\@head.cfa.harvard.edu malgosia\@head.cfa.harvard.edu";
+    open MAIL, "|mailx -s config_mon_2.6 swolk\@cfa.harvard.edu msobolewska\@cfa.harvard.edu";
     #open MAIL, "|more"; #debug
     print MAIL "config_mon_2.6 \n\n"; # current version
     if ( -s $dumpname ) {
@@ -1654,7 +1654,7 @@ if ( -s $outfile ) {
     print MAIL "Future violations will not be reported until rearmed by MTA.\n";
     #print MAIL "This message sent to sot_lead brad jnichols\n";
     #print MAIL "This message sent to sot_yellow_alert\n";
-    print MAIL "This message sent to swolk brad malgosia.\n";
+    print MAIL "This message sent to swolk malgosia.\n";
     close MAIL;
     close LOCK;
   }  #endelse
@@ -1672,7 +1672,7 @@ $lockfile = "./.dumps_mon_aca_lock";
 if ( -s $acafile ) {
   if ( -s $lockfile ) {  # already sent, don't send again
     #open MAIL, "|mailx -s config_mon_test swolk brad\@head.cfa.harvard.edu acisdude\@head.cfa.harvard.edu";
-    open MAIL, "|mailx -s config_mon_2.6 swolk brad\@head.cfa.harvard.edu malgosia\@head.cfa.harvard.edu";
+    open MAIL, "|mailx -s config_mon_2.6 swolk\@cfa.harvard.edu msobolewska\@cfa.harvard.edu";
     #open MAIL, "|more"; #debug
     print MAIL "config_mon_2.6 \n\n"; # current version
     if ( -s $dumpname ) {
@@ -1695,7 +1695,7 @@ if ( -s $acafile ) {
   } else {  # first violation, tell someone
     #open MAIL, "|mail brad\@head.cfa.harvard.edu swolk\@head.cfa.harvard.edu";
     #open MAIL, "|mailx -s config_mon_test swolk brad\@head.cfa.harvard.edu";
-    open MAIL, "|mailx -s config_mon_2.6 swolk brad\@head.cfa.harvard.edu malgosia\@head.cfa.harvard.edu";
+    open MAIL, "|mailx -s config_mon_2.6 swolk\@cfa.harvard.edu msobolewska\@cfa.harvard.edu";
     #open MAIL, "|more"; #debug
     print MAIL "config_mon_2.6\n\n"; # current version
     if ( -s $dumpname ) {
@@ -1730,7 +1730,7 @@ $lockfile = "./.dumps_mon_acis_lock";
 if ( -s $aoutfile ) {
   if ( -s $lockfile ) {  # already sent, don't send again
     #open MAIL, "|mailx -s config_mon_test swolk brad\@head.cfa.harvard.edu plucinsk\@head.cfa.harvard.edu";
-    open MAIL, "|mailx -s config_mon_2.6 swolk brad\@head.cfa.harvard.edu malgosia\@head.cfa.harvard.edu";
+    open MAIL, "|mailx -s config_mon_2.6 swolk\@cfa.harvard.edu msobolewska\@cfa.harvard.edu";
     #open MAIL, "|mailx -s config_mon_test swolk brad\@head.cfa.harvard.edu";
     #open MAIL, "|more"; #debug
     print MAIL "config_mon_2.6 \n\n"; # current version
@@ -1749,12 +1749,12 @@ if ( -s $aoutfile ) {
       print MAIL $_;
       print LOCK $_;
     }
-    print MAIL "This message sent to swolk brad malgosia.\n";
+    print MAIL "This message sent to swolk malgosia.\n";
     close MAIL;
     close LOCK;
   } else {  # first violation, tell someone
     #open MAIL, "|mailx -s config_mon sot_yellow_alert\@head.cfa.harvard.edu";
-    open MAIL, "|mailx -s config_mon_2.6 swolk brad\@head.cfa.harvard.edu malgosia\@head.cfa.harvard.edu";
+    open MAIL, "|mailx -s config_mon_2.6 swolk\@cfa.harvard.edu msobolewska\@cfa.harvard.edu";
     #open MAIL, "|mail brad\@head.cfa.harvard.edu swolk\@head.cfa.harvard.edu";
     #open MAIL, "|mailx -s config_mon_test swolk brad\@head.cfa.harvard.edu";
     #open MAIL, "|more"; #debug
@@ -1777,7 +1777,7 @@ if ( -s $aoutfile ) {
     }
     print MAIL "Future violations will not be reported until rearmed by MTA.\n";
     #print MAIL "This message sent to sot_yellow_alert\n";
-    print MAIL "This message sent to swolk brad malgosia.\n";
+    print MAIL "This message sent to swolk malgosia.\n";
     close MAIL;
     close LOCK;
   }  #endelse
@@ -1796,7 +1796,7 @@ if ( -s $atoutfile ) {
   if ( -s $lockfile ) {  # already sent, don't send again
     #open MAIL, "|mailx -s config_mon_test swolk brad\@head.cfa.harvard.edu plucinsk\@head.cfa.harvard.edu";
     #open MAIL, "|mailx -s config_mon_test swolk brad\@head.cfa.harvard.edu 6172573986\@mobile.mycingular.com 6177216763\@vtext.com";
-    open MAIL, "|mailx -s config_mon_2.6 swolk brad\@head.cfa.harvard.edu malgosia\@head.cfa.harvard.edu";
+    open MAIL, "|mailx -s config_mon_2.6 swolk\@cfa.harvard.edu msobolewska\@cfa.harvard.edu";
     #open MAIL, "|more"; #debug
     print MAIL "config_mon_2.6 \n\n"; # current version
     if ( -s $dumpname ) {
@@ -1814,12 +1814,12 @@ if ( -s $atoutfile ) {
       print MAIL $_;
       print LOCK $_;
     }
-    print MAIL "This message sent to swolk brad malgosia.\n";
+    print MAIL "This message sent to swolk malgosia.\n";
     close MAIL;
     close LOCK;
   } else {  # first violation, tell someone
     #open MAIL, "|mailx -s config_mon_test swolk brad\@head.cfa.harvard.edu 6172573986\@mobile.mycingular.com 6177216763\@vtext.com";
-    open MAIL, "|mailx -s config_mon_2.6 swolk brad\@head.cfa.harvard.edu malgosia\@head.cfa.harvard.edu";
+    open MAIL, "|mailx -s config_mon_2.6 swolk\@cfa.harvard.edu msobolewska\@cfa.harvard.edu";
     #open MAIL, "|more"; #debug
     print MAIL "config_mon_2.6\n\n"; # current version
     if ( -s $dumpname ) {
@@ -1840,7 +1840,7 @@ if ( -s $atoutfile ) {
     }
     print MAIL "Future violations will not be reported until rearmed by MTA.\n";
     #print MAIL "This message sent to sot_yellow_alert\n";
-    print MAIL "This message sent to swolk brad malgosia.\n";
+    print MAIL "This message sent to swolk malgosia.\n";
     close MAIL;
     close LOCK;
   }  #endelse
@@ -1858,7 +1858,7 @@ $lockfile = "./.dumps_mon_deatemp_lock";
 if ( -s $doutfile ) {
   if ( -s $lockfile ) {  # already sent, don't send again
     #open MAIL, "|mailx -s config_mon_test swolk brad\@head.cfa.harvard.edu plucinsk\@head.cfa.harvard.edu";
-    open MAIL, "|mailx -s config_mon_2.6 swolk brad\@head.cfa.harvard.edu malgosia\@head.cfa.harvard.edu";
+    open MAIL, "|mailx -s config_mon_2.6 swolk\@cfa.harvard.edu msobolewska\@cfa.harvard.edu";
     #open MAIL, "|more"; #debug
     print MAIL "config_mon_2.6 \n\n"; # current version
     if ( -s $dumpname ) {
@@ -1876,12 +1876,12 @@ if ( -s $doutfile ) {
       print MAIL $_;
       print LOCK $_;
     }
-    print MAIL "This message sent to swolk brad malgosia.\n";
+    print MAIL "This message sent to swolk malgosia.\n";
     close MAIL;
     close LOCK;
   } else {  # first violation, tell someone
     #open MAIL, "|mailx -s config_mon sot_yellow_alert\@head.cfa.harvard.edu";
-    open MAIL, "|mailx -s config_mon_2.6 swolk brad\@head.cfa.harvard.edu malgosia\@head.cfa.harvard.edu";
+    open MAIL, "|mailx -s config_mon_2.6 swolk\@cfa.harvard.edu msobolewska\@cfa.harvard.edu";
     #open MAIL, "|mail brad\@head.cfa.harvard.edu swolk\@head.cfa.harvard.edu";
     #open MAIL, "|mailx -s config_mon_test swolk brad\@head.cfa.harvard.edu";
     #open MAIL, "|more"; #debug
@@ -1904,7 +1904,7 @@ if ( -s $doutfile ) {
     }
     print MAIL "Future violations will not be reported until rearmed by MTA.\n";
     #print MAIL "This message sent to sot_yellow_alert\n";
-    print MAIL "This message sent to swolk brad malgosia.\n";
+    print MAIL "This message sent to swolk malgosia.\n";
     close MAIL;
     close LOCK;
   }  #endelse
@@ -1920,7 +1920,7 @@ unlink $doutfile;
 $lockfile = "./.dumps_mon_iru_lock";
 if ( -s $ioutfile ) {
   if ( -s $lockfile ) {  # already sent, don't send again
-    open MAIL, "|mailx -s config_mon_2.6 swolk brad\@head.cfa.harvard.edu malgosia\@head.cfa.harvard.edu";
+    open MAIL, "|mailx -s config_mon_2.6 swolk\@cfa.harvard.edu msobolewska\@cfa.harvard.edu";
     #open MAIL, "|more"; #debug
     print MAIL "config_mon_2.6 \n\n"; # current version
     if ( -s $dumpname ) {
@@ -1938,11 +1938,11 @@ if ( -s $ioutfile ) {
       print MAIL $_;
       print LOCK $_;
     }
-    print MAIL "This message sent to swolk brad malgosia.\n";
+    print MAIL "This message sent to swolk malgosia.\n";
     close MAIL;
     close LOCK;
   } else {  # first violation, tell someone
-    open MAIL, "|mailx -s config_mon_2.6 swolk brad\@head.cfa.harvard.edu malgosia\@head.cfa.harvard.edu";
+    open MAIL, "|mailx -s config_mon_2.6 swolk\@cfa.harvard.edu msobolewska\@cfa.harvard.edu";
     #open MAIL, "|mailx -s config_mon sot_red_alert\@head.cfa.harvard.edu";
     #open MAIL, "|mailx -s config_mon sot_yellow_alert\@head.cfa.harvard.edu";
     #open MAIL, "|more"; #debug
@@ -1966,7 +1966,7 @@ if ( -s $ioutfile ) {
     #print MAIL "Future violations will not be reported until rearmed by MTA.\n";
     #print MAIL "This message sent to sot_yellow_alert\n";
     #print MAIL "This message sent to sot_red_alert\n";
-    print MAIL "This message sent to swolk brad malgosia.\n";
+    print MAIL "This message sent to swolk malgosia.\n";
     #print MAIL "TEST_MODE TEST_MODE TEST_MODE\n";
     close MAIL;
     close LOCK;
@@ -1982,7 +1982,7 @@ unlink $ioutfile;
 $lockfile = "./.dumps_mon_eph_lock";
 if ( -s $eoutfile ) {
   if ( -s $lockfile ) {  # already sent, don't send again
-    open MAIL, "|mailx -s config_mon_2.6 swolk brad\@head.cfa.harvard.edu malgosia\@head.cfa.harvard.edu";
+    open MAIL, "|mailx -s config_mon_2.6 swolk\@cfa.harvard.edu msobolewska\@cfa.harvard.edu";
     #open MAIL, "|more"; #debug
     print MAIL "config_mon_2.6 \n\n"; # current version
     if ( -s $dumpname ) {
@@ -2000,12 +2000,12 @@ if ( -s $eoutfile ) {
       print MAIL $_;
       print LOCK $_;
     }
-    print MAIL "This message sent to swolk brad malgosia.\n";
+    print MAIL "This message sent to swolk malgosia.\n";
     close MAIL;
     close LOCK;
   } else {  # first violation, tell someone
     #open MAIL, "|mailx -s config_mon_test swolk brad\@head.cfa.harvard.edu";
-    open MAIL, "|mailx -s config_mon_2.6 swolk brad\@head.cfa.harvard.edu malgosia\@head.cfa.harvard.edu";
+    open MAIL, "|mailx -s config_mon_2.6 swolk\@cfa.harvard.edu msobolewska\@cfa.harvard.edu";
     #open MAIL, "|mailx -s config_mon sot_red_alert\@head.cfa.harvard.edu";
     #open MAIL, "|mailx -s config_mon sot_yellow_alert\@head.cfa.harvard.edu";
     #open MAIL, "|more"; #debug
@@ -2029,7 +2029,7 @@ if ( -s $eoutfile ) {
     #print MAIL "Future violations will not be reported until rearmed by MTA.\n";
     #print MAIL "This message sent to sot_yellow_alert\n";
     #print MAIL "This message sent to sot_red_alert\n";
-    print MAIL "This message sent to swolk brad malgosia.\n";  #turnbackon
+    print MAIL "This message sent to swolk malgosia.\n";  #turnbackon
     #print MAIL "This message sent to sot_lead\n";
     #print MAIL "TEST_MODE TEST_MODE TEST_MODE\n";  #turnbackon
     close MAIL;
@@ -2044,7 +2044,7 @@ unlink $eoutfile;
 $lockfile = "./.dumps_mon_ephv_lock";
 if ( -s $evoutfile ) {
   if ( -s $lockfile ) {  # already sent, don't send again
-    open MAIL, "|mailx -s config_mon_2.6 swolk brad\@head.cfa.harvard.edu malgosia\@head.cfa.harvard.edu";
+    open MAIL, "|mailx -s config_mon_2.6 swolk\@cfa.harvard.edu msobolewska\@cfa.harvard.edu";
     #open MAIL, "|more"; #debug
     print MAIL "config_mon_2.6 \n\n"; # current version
     if ( -s $dumpname ) {
@@ -2062,12 +2062,12 @@ if ( -s $evoutfile ) {
       print MAIL $_;
       print LOCK $_;
     }
-    print MAIL "This message sent to swolk brad malgosia.\n";
+    print MAIL "This message sent to swolk malgosia.\n";
     close MAIL;
     close LOCK;
   } else {  # first violation, tell someone
     #open MAIL, "|mailx -s config_mon_test swolk brad\@head.cfa.harvard.edu swolk\@head.cfa.harvard.edu";
-    open MAIL, "|mailx -s config_mon_2.6 swolk brad\@head.cfa.harvard.edu malgosia\@head.cfa.harvard.edu";
+    open MAIL, "|mailx -s config_mon_2.6 swolk\@cfa.harvard.edu msobolewska\@cfa.harvard.edu";
     #open MAIL, "|mailx -s config_mon sot_yellow_alert\@head.cfa.harvard.edu";
     #open MAIL, "|more"; #debug
     print MAIL "config_mon_2.6 \n\n"; # current version
@@ -2089,7 +2089,7 @@ if ( -s $evoutfile ) {
     }
     #print MAIL "Future violations will not be reported until rearmed by MTA.\n";
     #print MAIL "This message sent to sot_yellow_alert\n";
-    print MAIL "This message sent to swolk brad malgosia.\n";
+    print MAIL "This message sent to swolk malgosia.\n";
     #print MAIL "This message sent to brad swolk1\n";
     #print MAIL "This message sent to sot_lead fot emartin\n";
     #print MAIL "TEST_MODE TEST_MODE TEST_MODE\n";
@@ -2108,7 +2108,7 @@ unlink $evoutfile;
 $lockfile = "./.dumps_mon_mups_lock";
 if ( -s $poutfile ) {
   if ( -s $lockfile ) {  # already sent, don't send again
-    open MAIL, "|mailx -s config_mon_2.6 swolk brad\@head.cfa.harvard.edu malgosia\@head.cfa.harvard.edu";
+    open MAIL, "|mailx -s config_mon_2.6 swolk\@cfa.harvard.edu msobolewska\@cfa.harvard.edu";
     print MAIL "config_mon_2.6 \n\n"; # current version
     if ( -s $dumpname ) {
       open DNAME, "<$dumpname";
@@ -2125,11 +2125,11 @@ if ( -s $poutfile ) {
       print MAIL $_;
       print LOCK $_;
     }
-    print MAIL "This message sent to swolk brad malgosia.\n";
+    print MAIL "This message sent to swolk malgosia.\n";
     close MAIL;
     close LOCK;
   } else {  # first violation, tell someone
-    open MAIL, "|mailx -s config_mon_2.6 swolk brad\@head.cfa.harvard.edu malgosia\@head.cfa.harvard.edu";
+    open MAIL, "|mailx -s config_mon_2.6 swolk\@cfa.harvard.edu msobolewska\@cfa.harvard.edu";
     #open MAIL, "|mailx -s config_mon sot_yellow_alert\@head.cfa.harvard.edu";
     #open MAIL, "|more"; #debug
     print MAIL "config_mon_2.6\n\n"; # current version
@@ -2152,7 +2152,7 @@ if ( -s $poutfile ) {
     #print MAIL "Future violations will not be reported until rearmed by MTA.\n";
     #print MAIL "This message sent to sot_yellow_alert\n";
     #print MAIL "This message sent to sot_red_alert\n";
-    print MAIL "This message sent to swolk brad malgosia.\n";  #turnbackon
+    print MAIL "This message sent to swolk malgosia.\n";  #turnbackon
     #print MAIL "This message sent to sot_lead\n";
     #print MAIL "TEST_MODE TEST_MODE TEST_MODE\n";  #turnbackon
     close MAIL;

--- a/snapshot/check_state.pm
+++ b/snapshot/check_state.pm
@@ -1191,8 +1191,8 @@ sub send_tank_red {
     print FILE "\nSnapshot:\n";
     print FILE "http://cxc.harvard.edu/cgi-gen/mta/Snap/snap.cgi\n"; #debug
     close FILE;
-    #open MAIL, "|mailx -s PMTANKP_test brad\@head.cfa.harvard.edu,swolk";
-    open MAIL, "|mailx -s PMTANKP sot_red_alert\@head.cfa.harvard.edu";
+    #open MAIL, "|mailx -s PMTANKP_test msobolewska\@cfa.harvard.edu,swolk";
+    open MAIL, "|mailx -s PMTANKP sot_red_alert\@cfa.harvard.edu";
     #open MAIL, "|more"; #debug
     open FILE, $afile;
     while (<FILE>) {
@@ -1217,8 +1217,8 @@ sub send_tank_yellow {
     print FILE "\nSnapshot:\n";
     print FILE "http://cxc.harvard.edu/cgi-gen/mta/Snap/snap.cgi\n"; #debug
     close FILE;
-    #open MAIL, "|mailx -s PMTANKP brad\@head.cfa.harvard.edu";
-    open MAIL, "|mailx -s PMTANKP sot_yellow_alert\@head.cfa.harvard.edu";
+    #open MAIL, "|mailx -s PMTANKP msobolewska\@cfa.harvard.edu";
+    open MAIL, "|mailx -s PMTANKP sot_yellow_alert\@cfa.harvard.edu";
     #open MAIL, "|more"; #debug
     open FILE, $afile;
     while (<FILE>) {
@@ -1287,13 +1287,13 @@ sub send_107_alert {
     #print FILE "\n TEST   TEST   TEST   TEST   TEST   TEST   TEST\n"; #debug
     close FILE;
 
-    #open MAIL, "|mail brad\@head.cfa.harvard.edu swolk\@head.cfa.harvard.edu rac\@head.cfa.harvard.edu";
-    #open MAIL, "|mail brad\@head.cfa.harvard.edu swolk\@head.cfa.harvard.edu";
-    #open MAIL, "|mail sot_yellow_alert\@head.cfa.harvard.edu";
-    #open MAIL, "|mailx -s SCS107 sot_red_alert\@head.cfa.harvard.edu";
-    open MAIL, "|mailx -s 'SCS107 telecon 111165\# now' sot_red_alert\@head.cfa.harvard.edu operators\@head.cfa.harvard.edu";
+    #open MAIL, "|mail msobolewska\@cfa.harvard.edu swolk\@cfa.harvard.edu rac\@cfa.harvard.edu";
+    #open MAIL, "|mail msobolewska\@cfa.harvard.edu swolk\@cfa.harvard.edu";
+    #open MAIL, "|mail sot_yellow_alert\@cfa.harvard.edu";
+    #open MAIL, "|mailx -s SCS107 sot_red_alert\@cfa.harvard.edu";
+    open MAIL, "|mailx -s 'SCS107 telecon 111165\# now' sot_red_alert\@cfa.harvard.edu operators\@cfa.harvard.edu";
     #open MAIL, "|mailx -s 'SCS107 telecon 111165\# now' 617257386\@mms.att.net";
-    #open MAIL, "|mailx -s SCS107 brad\@head.cfa.harvard.edu";
+    #open MAIL, "|mailx -s SCS107 msobolewska\@cfa.harvard.edu";
     #open MAIL, "|more"; #debug
     open FILE, $afile;
     while (<FILE>) {
@@ -1353,10 +1353,10 @@ sub send_nsun_alert {
     #print FILE "\n TEST   TEST   TEST   TEST   TEST   TEST   TEST\n"; #debug
     close FILE;
 
-    #open MAIL, "|mailx -s NSUN brad\@head.cfa.harvard.edu swolk\@head.cfa.harvard.edu";
-    #open MAIL, "|mailx -s NSUN sot_yellow_alert\@head.cfa.harvard.edu";
-    open MAIL, "|mailx -s NSUN sot_red_alert\@head.cfa.harvard.edu";
-    #open MAIL, "|mailx -s NSUN sot_red_alert\@head.cfa.harvard.edu operators\@head.cfa.harvard.edu";
+    #open MAIL, "|mailx -s NSUN msobolewska\@cfa.harvard.edu swolk\@cfa.harvard.edu";
+    #open MAIL, "|mailx -s NSUN sot_yellow_alert\@cfa.harvard.edu";
+    open MAIL, "|mailx -s 'NSUN telecon 111165\# now' sot_red_alert\@cfa.harvard.edu";
+    #open MAIL, "|mailx -s NSUN sot_red_alert\@cfa.harvard.edu operators\@cfa.harvard.edu";
     #open MAIL, "|more"; #debug
     open FILE, $afile;
     while (<FILE>) {
@@ -1384,8 +1384,8 @@ sub send_sim_unsafe_alert {
     print FILE "This message sent to swolk, malgosia\n"; #debug
     close FILE;
 
-    open MAIL, "|mailx -s SIM_UNSAFE! swolk,malgosia";
-    #open MAIL, "|mailx -s SIM_UNSAFE! sot_yellow_alert\@head.cfa.harvard.edu";
+    open MAIL, "|mailx -s SIM_UNSAFE! swolk\@cfa.harvard.edu msobolewska\@cfa.harvard.edu";
+    #open MAIL, "|mailx -s SIM_UNSAFE! sot_yellow_alert\@cfa.harvard.edu";
     open FILE, $afile;
     while (<FILE>) {
       print MAIL $_;
@@ -1411,11 +1411,10 @@ sub send_hrc_shld_alert {
     print FILE "This message sent to sot_lead\n"; #debug
     close FILE;
 
-    #open MAIL, "|mailx -s 'HRC SHIELD' brad\@head.cfa.harvard.edu";
-    #open MAIL, "|mailx -s 'HRC SHIELD' brad\@head.cfa.harvard.edu swolk\@head.cfa.harvard.edu";
-    #open MAIL, "|mailx -s 'HRC SHIELD' sot_lead\@head.cfa.harvard.edu brad\@head.cfa.harvard.edu";
-    #open MAIL, "|mailx -s 'HRC SHIELD' 6172573986\@mobile.mycingular.com";
-    open MAIL, "|mailx -s 'HRC SHIELD' sot_yellow_alert\@head.cfa.harvard.edu 6172573986\@mobile.mycingular.com";
+    #open MAIL, "|mailx -s 'HRC SHIELD' msobolewska\@cfa.harvard.edu";
+    #open MAIL, "|mailx -s 'HRC SHIELD' msobolewska\@cfa.harvard.edu swolk\@cfa.harvard.edu";
+    #open MAIL, "|mailx -s 'HRC SHIELD' sot_lead\@cfa.harvard.edu msobolewska\@cfa.harvard.edu";
+    open MAIL, "|mailx -s 'HRC SHIELD' sot_yellow_alert\@cfa.harvard.edu 6172573986\@mobile.mycingular.com";
     open FILE, $afile;
     while (<FILE>) {
       print MAIL $_;
@@ -1480,12 +1479,12 @@ sub send_brit_alert {
     #print FILE "\n TEST   TEST   TEST   TEST   TEST   TEST   TEST\n"; #debug
     close FILE;
 
-    #open MAIL, "|mail brad\@head.cfa.harvard.edu swolk\@head.cfa.harvard.edu rac\@head.cfa.harvard.edu";
-    #open MAIL, "|mail brad\@head.cfa.harvard.edu swolk\@head.cfa.harvard.edu";
-    #open MAIL, "|mailx -s BRIT sot_yellow_alert\@head.cfa.harvard.edu";
-    open MAIL, "|mailx -s 'BRIT telecon 111165\# now' sot_red_alert\@head.cfa.harvard.edu";
-    #open MAIL, "|mailx -s BRIT brad\@head.cfa.harvard.edu";
-    #open MAIL, "|mail brad\@head.cfa.harvard.edu";
+    #open MAIL, "|mail msobolewska\@cfa.harvard.edu swolk\@cfa.harvard.edu rac\@cfa.harvard.edu";
+    #open MAIL, "|mail msobolewska\@cfa.harvard.edu swolk\@cfa.harvard.edu";
+    #open MAIL, "|mailx -s BRIT sot_yellow_alert\@cfa.harvard.edu";
+    open MAIL, "|mailx -s 'BRIT telecon 111165\# now' sot_red_alert\@cfa.harvard.edu";
+    #open MAIL, "|mailx -s BRIT msobolewska\@cfa.harvard.edu";
+    #open MAIL, "|mail msobolewska\@cfa.harvard.edu";
     #open MAIL, "|more"; #debug
     open FILE, $afile;
     while (<FILE>) {
@@ -1544,8 +1543,8 @@ sub send_cpe_alert {
     #print FILE "This message sent to sot_safemode_alert\n"; #debug
     close FILE;
 
-    #open MAIL, "|mailx -s CPEstat sot_safemode_alert\@head.cfa.harvard.edu";
-    open MAIL, "|mailx -s CPEstat malgosia\@head.cfa.harvard.edu";
+    #open MAIL, "|mailx -s CPEstat sot_safemode_alert\@cfa.harvard.edu";
+    open MAIL, "|mailx -s CPEstat msobolewska\@cfa.harvard.edu";
     #open MAIL, "|more"; #debug
     open FILE, $afile;
     while (<FILE>) {
@@ -1605,10 +1604,9 @@ sub send_fmt_alert {
     #print FILE "\n TEST   TEST   TEST   TEST   TEST   TEST   TEST\n"; #debug
     close FILE;
 
-    #open MAIL, "|mail brad\@head.cfa.harvard.edu swolk\@head.cfa.harvard.edu rac\@head.cfa.harvard.edu";
-    open MAIL, "|mailx -s 'FMT5: telecon 111165\# now' sot_safemode_alert\@head.cfa.harvard.edu";
-    #open MAIL, "|mailx -s 'FMT5: testcon 111165\# now' brad\@head.cfa.harvard.edu";
-    #open MAIL, "|mail brad\@head.cfa.harvard.edu";
+    #open MAIL, "|mail msobolewska\@cfa.harvard.edu swolk\@cfa.harvard.edu rac\@cfa.harvard.edu";
+    open MAIL, "|mailx -s 'FMT5: telecon 111165\# now' sot_safemode_alert\@cfa.harvard.edu";
+    #open MAIL, "|mail msobolewska\@cfa.harvard.edu";
     #open MAIL, "|more"; #debug
     open FILE, $afile;
     while (<FILE>) {
@@ -1668,9 +1666,9 @@ sub send_gyro_alert {
     #print FILE "\n TEST   TEST   TEST   TEST   TEST   TEST   TEST\n"; #debug
     close FILE;
 
-    #open MAIL, "|mailx -s AIRU1G1I brad\@head.cfa.harvard.edu swolk\@head.cfa.harvard.edu 6172573986\@mobile.mycingular.com";
-    open MAIL, "|mailx -s AIRU1G1I malgosia\@head.cfa.harvard.edu";
-    #open MAIL, "|mailx -s AIRU1G1I sot_red_alert\@head.cfa.harvard.edu";
+    #open MAIL, "|mailx -s AIRU1G1I msobolewska\@cfa.harvard.edu swolk\@cfa.harvard.edu 6172573986\@mobile.mycingular.com";
+    open MAIL, "|mailx -s AIRU1G1I msobolewska\@cfa.harvard.edu";
+    #open MAIL, "|mailx -s AIRU1G1I sot_red_alert\@cfa.harvard.edu";
     open FILE, $afile;
     while (<FILE>) {
       print MAIL $_;
@@ -1694,8 +1692,8 @@ sub send_ctxpwr_alert {
     print FILE "This message sent to sot_yellow_alert\n"; #debug
     close FILE;
 
-    #open MAIL, "|mailx -s CTXPWR brad\@head.cfa.harvard.edu swolk\@head.cfa.harvard.edu";
-    open MAIL, "|mailx -s CTXPWR sot_yellow_alert\@head.cfa.harvard.edu";
+    #open MAIL, "|mailx -s CTXPWR msobolewska\@cfa.harvard.edu swolk\@cfa.harvard.edu";
+    open MAIL, "|mailx -s CTXPWR sot_yellow_alert\@cfa.harvard.edu";
     open FILE, $afile;
     while (<FILE>) {
       print MAIL $_;
@@ -1719,8 +1717,8 @@ sub send_ctxv_alert {
     print FILE "This message sent to sot_yellow_alert\n"; #debug
     close FILE;
 
-    #open MAIL, "|mailx -s CTXV brad\@head.cfa.harvard.edu swolk\@head.cfa.harvard.edu";
-    open MAIL, "|mailx -s CTXV sot_yellow_alert\@head.cfa.harvard.edu";
+    #open MAIL, "|mailx -s CTXV msobolewska\@cfa.harvard.edu swolk\@cfa.harvard.edu";
+    open MAIL, "|mailx -s CTXV sot_yellow_alert\@cfa.harvard.edu";
     open FILE, $afile;
     while (<FILE>) {
       print MAIL $_;
@@ -1745,9 +1743,9 @@ sub send_hkp27v_alert {
     #print FILE "This message sent to sot_lead,fot,emartin\n"; #debug
     close FILE;
 
-    #open MAIL, "|mailx -s HKP27V sot_yellow_alert\@head.cfa.harvard.edu";
+    #open MAIL, "|mailx -s HKP27V sot_yellow_alert\@cfa.harvard.edu";
     #open MAIL, "|mailx -s HKP27V juda\@head.cfa.harvard.edu plucinsk\@head.cfa.harvard.edu aldcroft\@head.cfa.harvard.edu wap\@head.cfa.harvard.edu swolk\@head.cfa.harvard.edu das\@head.cfa.harvard.edu emk\@head.cfa.harvard.edu nadams\@head.cfa.harvard.edu depasq\@head.cfa.harvard.edu fot\@head.cfa.harvard.edu emartin\@head.cfa.harvard.edu 8572591479\@vtext brad\@head.cfa.harvard.edu";
-    open MAIL, "|mailx -s HKP27V swolk\@head.cfa.harvard.edu malgosia\@head.cfa.harvard.edu";
+    open MAIL, "|mailx -s HKP27V swolk\@cfa.harvard.edu msobolewska\@cfa.harvard.edu";
     open FILE, $afile;
     while (<FILE>) {
       print MAIL $_;
@@ -1771,8 +1769,8 @@ sub send_pline03t_alert {
     print FILE "This message sent to sot_yellow_alert\n"; #debug
     close FILE;
 
-    #open MAIL, "|mailx -s PLINE03T brad\@head.cfa.harvard.edu";
-    open MAIL, "|mailx -s PLINE03T sot_yellow_alert\@head.cfa.harvard.edu";
+    #open MAIL, "|mailx -s PLINE03T msobolewska\@cfa.harvard.edu";
+    open MAIL, "|mailx -s PLINE03T sot_yellow_alert\@cfa.harvard.edu";
     open FILE, $afile;
     while (<FILE>) {
       print MAIL $_;
@@ -1796,8 +1794,8 @@ sub send_pline04t_alert {
     print FILE "This message sent to sot_yellow_alert\n"; #debug
     close FILE;
 
-    #open MAIL, "|mailx -s PLINE04T brad\@head.cfa.harvard.edu";
-    open MAIL, "|mailx -s PLINE04T sot_yellow_alert\@head.cfa.harvard.edu";
+    #open MAIL, "|mailx -s PLINE04T msobolewska\@cfa.harvard.edu";
+    open MAIL, "|mailx -s PLINE04T sot_yellow_alert\@cfa.harvard.edu";
     open FILE, $afile;
     while (<FILE>) {
       print MAIL $_;
@@ -1821,7 +1819,7 @@ sub send_aacccdpt_yellow_alert {
     #print FILE "This message sent to taldcroft\n"; #debug
     close FILE;
 
-    open MAIL, "|mailx -s AACCCDPT jeanconn,aldcroft,emartin,malgosia";
+    open MAIL, "|mailx -s AACCCDPT jeanconn,aldcroft,emartin,msobolewska\@cfa.harvard.edu";
     #open MAIL, "|mailx -s AACCCDPT brad";
     open FILE, $afile;
     while (<FILE>) {
@@ -1846,8 +1844,8 @@ sub send_aacccdpt_red_alert {
     print FILE "This message sent to malgosia\n"; #debug
     close FILE;
 
-    open MAIL, "|mailx -s AACCCDPT malgosia\@head.cfa.harvard.edu";
-    #open MAIL, "|mailx -s AACCCDPT sot_red_alert\@head.cfa.harvard.edu,aspect_help,6177214364\@vtext.com,8572591479\@vtext";
+    open MAIL, "|mailx -s AACCCDPT msobolewska\@cfa.harvard.edu";
+    #open MAIL, "|mailx -s AACCCDPT sot_red_alert\@cfa.harvard.edu,aspect_help,6177214364\@vtext.com,8572591479\@vtext";
     open FILE, $afile;
     while (<FILE>) {
       print MAIL $_;
@@ -1872,8 +1870,8 @@ sub send_ldrtno_alert {
     print FILE "This message sent to sot_red_alert\n"; #debug
     close FILE;
 
-    #open MAIL, "|mailx -s 3LDRTNO brad\@head.cfa.harvard.edu";
-    open MAIL, "|mailx -s 3LDRTNO sot_red_alert\@head.cfa.harvard.edu";
+    #open MAIL, "|mailx -s 3LDRTNO msobolewska\@cfa.harvard.edu";
+    open MAIL, "|mailx -s 3LDRTNO sot_red_alert\@cfa.harvard.edu";
     open FILE, $afile;
     while (<FILE>) {
       print MAIL $_;

--- a/snapshot/check_state_alerts.pm
+++ b/snapshot/check_state_alerts.pm
@@ -1191,8 +1191,8 @@ sub send_tank_red {
     print FILE "\nSnapshot:\n";
     print FILE "http://cxc.harvard.edu/cgi-gen/mta/Snap/snap.cgi\n"; #debug
     close FILE;
-    #open MAIL, "|mailx -s PMTANKP_test brad\@head.cfa.harvard.edu,swolk";
-    open MAIL, "|mailx -s PMTANKP sot_red_alert\@head.cfa.harvard.edu";
+    #open MAIL, "|mailx -s PMTANKP_test msobolewska\@cfa.harvard.edu,swolk";
+    open MAIL, "|mailx -s PMTANKP sot_red_alert\@cfa.harvard.edu";
     #open MAIL, "|more"; #debug
     open FILE, $afile;
     while (<FILE>) {
@@ -1217,8 +1217,8 @@ sub send_tank_yellow {
     print FILE "\nSnapshot:\n";
     print FILE "http://cxc.harvard.edu/cgi-gen/mta/Snap/snap.cgi\n"; #debug
     close FILE;
-    #open MAIL, "|mailx -s PMTANKP brad\@head.cfa.harvard.edu";
-    open MAIL, "|mailx -s PMTANKP sot_yellow_alert\@head.cfa.harvard.edu";
+    #open MAIL, "|mailx -s PMTANKP msobolewska\@cfa.harvard.edu";
+    open MAIL, "|mailx -s PMTANKP sot_yellow_alert\@cfa.harvard.edu";
     #open MAIL, "|more"; #debug
     open FILE, $afile;
     while (<FILE>) {
@@ -1244,8 +1244,9 @@ sub send_107_alert {
     open FILE, ">$afile";
     #print FILE "  THIS IS ONLY A TEST !!!! \n\n"; #debug
     #print FILE "(Testing ... I wasn't working before, but now I am)\n"; #debug
-    print FILE "Chandra realtime telemetry shows SCS107 $_[0] at $obt UT\n\n";
-    print FILE "\nTelecon on 1-877-521-0441 111165\# now.\n";
+    print FILE "Chandra realtime telemetry shows SCS107 $_[0] at $obt UT\n";
+    print FILE "\nTelecon on 1-844-467-6272 111165\# now.\n";
+    print FILE "A reminder, this may be connected to the voice loops at OCC\n";
     # try to figure out next comm passes
     open COMS, $comfile;
     <COMS>;
@@ -1286,13 +1287,13 @@ sub send_107_alert {
     #print FILE "\n TEST   TEST   TEST   TEST   TEST   TEST   TEST\n"; #debug
     close FILE;
 
-    #open MAIL, "|mail brad\@head.cfa.harvard.edu swolk\@head.cfa.harvard.edu rac\@head.cfa.harvard.edu";
-    #open MAIL, "|mail brad\@head.cfa.harvard.edu swolk\@head.cfa.harvard.edu";
-    #open MAIL, "|mail sot_yellow_alert\@head.cfa.harvard.edu";
-    #open MAIL, "|mailx -s SCS107 sot_red_alert\@head.cfa.harvard.edu";
-    open MAIL, "|mailx -s 'SCS107 telecon 111165\# now' sot_red_alert\@head.cfa.harvard.edu operators\@head.cfa.harvard.edu";
+    #open MAIL, "|mail msobolewska\@cfa.harvard.edu swolk\@cfa.harvard.edu rac\@cfa.harvard.edu";
+    #open MAIL, "|mail msobolewska\@cfa.harvard.edu swolk\@cfa.harvard.edu";
+    #open MAIL, "|mail sot_yellow_alert\@cfa.harvard.edu";
+    #open MAIL, "|mailx -s SCS107 sot_red_alert\@cfa.harvard.edu";
+    open MAIL, "|mailx -s 'SCS107 telecon 111165\# now' sot_red_alert\@cfa.harvard.edu operators\@cfa.harvard.edu";
     #open MAIL, "|mailx -s 'SCS107 telecon 111165\# now' 617257386\@mms.att.net";
-    #open MAIL, "|mailx -s SCS107 brad\@head.cfa.harvard.edu";
+    #open MAIL, "|mailx -s SCS107 msobolewska\@cfa.harvard.edu";
     #open MAIL, "|more"; #debug
     open FILE, $afile;
     while (<FILE>) {
@@ -1314,6 +1315,8 @@ sub send_nsun_alert {
   } else {
     open FILE, ">$afile";
     print FILE "Chandra realtime telemetry shows PCADMODE $_[0] at $obt UT\n\n";
+    print FILE "\nTelecon on 1-844-467-6272 111165\# now.\n";
+    print FILE "A reminder, this may be connected to the voice loops at OCC\n";
     # try to figure out next comm passes
     open COMS, $comfile;
     my @time = split(":", $obt);
@@ -1350,10 +1353,10 @@ sub send_nsun_alert {
     #print FILE "\n TEST   TEST   TEST   TEST   TEST   TEST   TEST\n"; #debug
     close FILE;
 
-    #open MAIL, "|mailx -s NSUN brad\@head.cfa.harvard.edu swolk\@head.cfa.harvard.edu";
-    #open MAIL, "|mailx -s NSUN sot_yellow_alert\@head.cfa.harvard.edu";
-    open MAIL, "|mailx -s NSUN sot_red_alert\@head.cfa.harvard.edu";
-    #open MAIL, "|mailx -s NSUN sot_red_alert\@head.cfa.harvard.edu operators\@head.cfa.harvard.edu";
+    #open MAIL, "|mailx -s NSUN msobolewska\@cfa.harvard.edu swolk\@cfa.harvard.edu";
+    #open MAIL, "|mailx -s NSUN sot_yellow_alert\@cfa.harvard.edu";
+    open MAIL, "|mailx -s 'NSUN telecon 111165\# now' sot_red_alert\@cfa.harvard.edu";
+    #open MAIL, "|mailx -s NSUN sot_red_alert\@cfa.harvard.edu operators\@cfa.harvard.edu";
     #open MAIL, "|more"; #debug
     open FILE, $afile;
     while (<FILE>) {
@@ -1378,11 +1381,11 @@ sub send_sim_unsafe_alert {
       
     print FILE "\nSnapshot:\n";
     print FILE "http://cxc.harvard.edu/cgi-gen/mta/Snap/snap.cgi\n"; #debug
-    print FILE "This message sent to sot_yellow_alert\n"; #debug
+    print FILE "This message sent to swolk, malgosia\n"; #debug
     close FILE;
 
-    open MAIL, "|mailx -s SIM_UNSAFE! brad\@head.cfa.harvard.edu";
-    #open MAIL, "|mailx -s SIM_UNSAFE! sot_yellow_alert\@head.cfa.harvard.edu";
+    open MAIL, "|mailx -s SIM_UNSAFE! swolk\@cfa.harvard.edu msobolewska\@cfa.harvard.edu";
+    #open MAIL, "|mailx -s SIM_UNSAFE! sot_yellow_alert\@cfa.harvard.edu";
     open FILE, $afile;
     while (<FILE>) {
       print MAIL $_;
@@ -1408,10 +1411,10 @@ sub send_hrc_shld_alert {
     print FILE "This message sent to sot_lead\n"; #debug
     close FILE;
 
-    #open MAIL, "|mailx -s 'HRC SHIELD' brad\@head.cfa.harvard.edu";
-    #open MAIL, "|mailx -s 'HRC SHIELD' brad\@head.cfa.harvard.edu swolk\@head.cfa.harvard.edu";
-    #open MAIL, "|mailx -s 'HRC SHIELD' sot_lead\@head.cfa.harvard.edu brad\@head.cfa.harvard.edu";
-    open MAIL, "|mailx -s 'HRC SHIELD' sot_yellow_alert\@head.cfa.harvard.edu 6172573986\@mobile.mycingular.com";
+    #open MAIL, "|mailx -s 'HRC SHIELD' msobolewska\@cfa.harvard.edu";
+    #open MAIL, "|mailx -s 'HRC SHIELD' msobolewska\@cfa.harvard.edu swolk\@cfa.harvard.edu";
+    #open MAIL, "|mailx -s 'HRC SHIELD' sot_lead\@cfa.harvard.edu msobolewska\@cfa.harvard.edu";
+    open MAIL, "|mailx -s 'HRC SHIELD' sot_yellow_alert\@cfa.harvard.edu 6172573986\@mobile.mycingular.com";
     open FILE, $afile;
     while (<FILE>) {
       print MAIL $_;
@@ -1435,7 +1438,9 @@ sub send_brit_alert {
     open FILE, ">$afile";
     #print FILE "  THIS IS ONLY A TEST !!!! \n\n"; #debug
     #print FILE "(Testing ... I wasn't working before, but now I am)\n"; #debug
-    print FILE "Chandra realtime telemetry shows AOFSTAR $_[0] at $obt UT\n\n";
+    print FILE "Chandra realtime telemetry shows AOFSTAR $_[0] at $obt UT\n";
+    print FILE "\nTelecon on 1-844-467-6272 111165\# now.\n";
+    print FILE "A reminder, this may be connected to the voice loops at OCC\n";
     # try to figure out next comm passes
     open COMS, $comfile;
     my @time = split(":", $obt);
@@ -1467,19 +1472,19 @@ sub send_brit_alert {
     print FILE "\nSnapshot:\n";
     print FILE "http://cxc.harvard.edu/cgi-gen/mta/Snap/snap.cgi\n"; #debug
     #print FILE "http://cxc.harvard.edu/mta_days/MIRROR/Snap/snap.cgi\n"; #debug
-    print FILE "This message sent to sot_yellow_alert\n"; #debug
-    #print FILE "This message sent to sot_red_alert\n"; #debug
+    #print FILE "This message sent to sot_yellow_alert\n"; #debug
+    print FILE "This message sent to sot_red_alert\n"; #debug
     #print FILE "This message sent to brad rac swolk\n"; #debug
     #print FILE "This message sent to brad\n"; #debug
     #print FILE "\n TEST   TEST   TEST   TEST   TEST   TEST   TEST\n"; #debug
     close FILE;
 
-    #open MAIL, "|mail brad\@head.cfa.harvard.edu swolk\@head.cfa.harvard.edu rac\@head.cfa.harvard.edu";
-    #open MAIL, "|mail brad\@head.cfa.harvard.edu swolk\@head.cfa.harvard.edu";
-    open MAIL, "|mailx -s BRIT sot_yellow_alert\@head.cfa.harvard.edu";
-    #open MAIL, "|mailx -s BRIT sot_red_alert\@head.cfa.harvard.edu";
-    #open MAIL, "|mailx -s BRIT brad\@head.cfa.harvard.edu";
-    #open MAIL, "|mail brad\@head.cfa.harvard.edu";
+    #open MAIL, "|mail msobolewska\@cfa.harvard.edu swolk\@cfa.harvard.edu rac\@cfa.harvard.edu";
+    #open MAIL, "|mail msobolewska\@cfa.harvard.edu swolk\@cfa.harvard.edu";
+    #open MAIL, "|mailx -s BRIT sot_yellow_alert\@cfa.harvard.edu";
+    open MAIL, "|mailx -s 'BRIT telecon 111165\# now' sot_red_alert\@cfa.harvard.edu";
+    #open MAIL, "|mailx -s BRIT msobolewska\@cfa.harvard.edu";
+    #open MAIL, "|mail msobolewska\@cfa.harvard.edu";
     #open MAIL, "|more"; #debug
     open FILE, $afile;
     while (<FILE>) {
@@ -1534,12 +1539,12 @@ sub send_cpe_alert {
     print FILE "\nSnapshot:\n";
     print FILE "http://cxc.harvard.edu/cgi-gen/mta/Snap/snap.cgi\n"; #debug
     #print FILE "http://cxc.harvard.edu/mta_days/MIRROR/Snap/snap.cgi\n"; #debug
-    print FILE "This message sent to brad\n"; #debug
+    print FILE "This message sent to malgosia\n"; #debug
     #print FILE "This message sent to sot_safemode_alert\n"; #debug
     close FILE;
 
-    #open MAIL, "|mailx -s CPEstat sot_safemode_alert\@head.cfa.harvard.edu";
-    open MAIL, "|mailx -s CPEstat brad\@head.cfa.harvard.edu";
+    #open MAIL, "|mailx -s CPEstat sot_safemode_alert\@cfa.harvard.edu";
+    open MAIL, "|mailx -s CPEstat msobolewska\@cfa.harvard.edu";
     #open MAIL, "|more"; #debug
     open FILE, $afile;
     while (<FILE>) {
@@ -1562,8 +1567,9 @@ sub send_fmt_alert {
   } else {
     open FILE, ">$afile";
     #print FILE "  THIS IS ONLY A TEST !!!! \n\n"; #debug
-    print FILE "Chandra realtime telemetry shows FMT$_[0] at $obt UT\n\n";
-    print FILE "\nTelecon on 1-877-521-0441 111165\# now.\n";
+    print FILE "Chandra realtime telemetry shows FMT$_[0] at $obt UT\n";
+    print FILE "\nTelecon on 1-844-467-6272 111165\# now.\n";
+    print FILE "A reminder, this may be connected to the voice loops at OCC\n";
     # try to figure out next comm passes
     open COMS, $comfile;
     my @time = split(":", $obt);
@@ -1598,9 +1604,9 @@ sub send_fmt_alert {
     #print FILE "\n TEST   TEST   TEST   TEST   TEST   TEST   TEST\n"; #debug
     close FILE;
 
-    #open MAIL, "|mail brad\@head.cfa.harvard.edu swolk\@head.cfa.harvard.edu rac\@head.cfa.harvard.edu";
-    open MAIL, "|mailx -s 'FMT5: telecon 111165\# now' sot_safemode_alert\@head.cfa.harvard.edu";
-    #open MAIL, "|mail brad\@head.cfa.harvard.edu";
+    #open MAIL, "|mail msobolewska\@cfa.harvard.edu swolk\@cfa.harvard.edu rac\@cfa.harvard.edu";
+    open MAIL, "|mailx -s 'FMT5: telecon 111165\# now' sot_safemode_alert\@cfa.harvard.edu";
+    #open MAIL, "|mail msobolewska\@cfa.harvard.edu";
     #open MAIL, "|more"; #debug
     open FILE, $afile;
     while (<FILE>) {
@@ -1656,13 +1662,13 @@ sub send_gyro_alert {
     print FILE "http://cxc.harvard.edu/cgi-gen/mta/Snap/snap.cgi\n"; #debug
     #print FILE "This message sent to sot_red_alert\n"; #debug
     #print FILE "This message sent to swolk brad brad1\n"; #debug
-    print FILE "This message sent to brad brad1\n"; #debug
+    print FILE "This message sent to malgosia\n"; #debug
     #print FILE "\n TEST   TEST   TEST   TEST   TEST   TEST   TEST\n"; #debug
     close FILE;
 
-    #open MAIL, "|mailx -s AIRU1G1I brad\@head.cfa.harvard.edu swolk\@head.cfa.harvard.edu 6172573986\@mobile.mycingular.com";
-    open MAIL, "|mailx -s AIRU1G1I brad\@head.cfa.harvard.edu 6172573986\@mobile.mycingular.com";
-    #open MAIL, "|mailx -s AIRU1G1I sot_red_alert\@head.cfa.harvard.edu";
+    #open MAIL, "|mailx -s AIRU1G1I msobolewska\@cfa.harvard.edu swolk\@cfa.harvard.edu 6172573986\@mobile.mycingular.com";
+    open MAIL, "|mailx -s AIRU1G1I msobolewska\@cfa.harvard.edu";
+    #open MAIL, "|mailx -s AIRU1G1I sot_red_alert\@cfa.harvard.edu";
     open FILE, $afile;
     while (<FILE>) {
       print MAIL $_;
@@ -1686,8 +1692,8 @@ sub send_ctxpwr_alert {
     print FILE "This message sent to sot_yellow_alert\n"; #debug
     close FILE;
 
-    #open MAIL, "|mailx -s CTXPWR brad\@head.cfa.harvard.edu swolk\@head.cfa.harvard.edu";
-    open MAIL, "|mailx -s CTXPWR sot_yellow_alert\@head.cfa.harvard.edu";
+    #open MAIL, "|mailx -s CTXPWR msobolewska\@cfa.harvard.edu swolk\@cfa.harvard.edu";
+    open MAIL, "|mailx -s CTXPWR sot_yellow_alert\@cfa.harvard.edu";
     open FILE, $afile;
     while (<FILE>) {
       print MAIL $_;
@@ -1711,8 +1717,8 @@ sub send_ctxv_alert {
     print FILE "This message sent to sot_yellow_alert\n"; #debug
     close FILE;
 
-    #open MAIL, "|mailx -s CTXV brad\@head.cfa.harvard.edu swolk\@head.cfa.harvard.edu";
-    open MAIL, "|mailx -s CTXV sot_yellow_alert\@head.cfa.harvard.edu";
+    #open MAIL, "|mailx -s CTXV msobolewska\@cfa.harvard.edu swolk\@cfa.harvard.edu";
+    open MAIL, "|mailx -s CTXV sot_yellow_alert\@cfa.harvard.edu";
     open FILE, $afile;
     while (<FILE>) {
       print MAIL $_;
@@ -1737,8 +1743,9 @@ sub send_hkp27v_alert {
     #print FILE "This message sent to sot_lead,fot,emartin\n"; #debug
     close FILE;
 
-    #open MAIL, "|mailx -s HKP27V sot_yellow_alert\@head.cfa.harvard.edu";
-    open MAIL, "|mailx -s HKP27V juda\@head.cfa.harvard.edu plucinsk\@head.cfa.harvard.edu aldcroft\@head.cfa.harvard.edu wap\@head.cfa.harvard.edu swolk\@head.cfa.harvard.edu das\@head.cfa.harvard.edu emk\@head.cfa.harvard.edu nadams\@head.cfa.harvard.edu depasq\@head.cfa.harvard.edu fot\@head.cfa.harvard.edu emartin\@head.cfa.harvard.edu 8572591479\@vtext brad\@head.cfa.harvard.edu";
+    #open MAIL, "|mailx -s HKP27V sot_yellow_alert\@cfa.harvard.edu";
+    #open MAIL, "|mailx -s HKP27V juda\@head.cfa.harvard.edu plucinsk\@head.cfa.harvard.edu aldcroft\@head.cfa.harvard.edu wap\@head.cfa.harvard.edu swolk\@head.cfa.harvard.edu das\@head.cfa.harvard.edu emk\@head.cfa.harvard.edu nadams\@head.cfa.harvard.edu depasq\@head.cfa.harvard.edu fot\@head.cfa.harvard.edu emartin\@head.cfa.harvard.edu 8572591479\@vtext brad\@head.cfa.harvard.edu";
+    open MAIL, "|mailx -s HKP27V swolk\@cfa.harvard.edu msobolewska\@cfa.harvard.edu";
     open FILE, $afile;
     while (<FILE>) {
       print MAIL $_;
@@ -1762,8 +1769,8 @@ sub send_pline03t_alert {
     print FILE "This message sent to sot_yellow_alert\n"; #debug
     close FILE;
 
-    #open MAIL, "|mailx -s PLINE03T brad\@head.cfa.harvard.edu";
-    open MAIL, "|mailx -s PLINE03T sot_yellow_alert\@head.cfa.harvard.edu";
+    #open MAIL, "|mailx -s PLINE03T msobolewska\@cfa.harvard.edu";
+    open MAIL, "|mailx -s PLINE03T sot_yellow_alert\@cfa.harvard.edu";
     open FILE, $afile;
     while (<FILE>) {
       print MAIL $_;
@@ -1787,8 +1794,8 @@ sub send_pline04t_alert {
     print FILE "This message sent to sot_yellow_alert\n"; #debug
     close FILE;
 
-    #open MAIL, "|mailx -s PLINE04T brad\@head.cfa.harvard.edu";
-    open MAIL, "|mailx -s PLINE04T sot_yellow_alert\@head.cfa.harvard.edu";
+    #open MAIL, "|mailx -s PLINE04T msobolewska\@cfa.harvard.edu";
+    open MAIL, "|mailx -s PLINE04T sot_yellow_alert\@cfa.harvard.edu";
     open FILE, $afile;
     while (<FILE>) {
       print MAIL $_;
@@ -1812,7 +1819,7 @@ sub send_aacccdpt_yellow_alert {
     #print FILE "This message sent to taldcroft\n"; #debug
     close FILE;
 
-    open MAIL, "|mailx -s AACCCDPT jeanconn,aldcroft,emartin,brad";
+    open MAIL, "|mailx -s AACCCDPT jeanconn,aldcroft,emartin,msobolewska\@cfa.harvard.edu";
     #open MAIL, "|mailx -s AACCCDPT brad";
     open FILE, $afile;
     while (<FILE>) {
@@ -1834,11 +1841,11 @@ sub send_aacccdpt_red_alert {
     open FILE, ">$afile";
     print FILE "Chandra realtime telemetry shows  AACCCDPT = $_[0] C at $obt UT\n";
     print FILE "Limit < 0 C\n\n";
-    print FILE "This message sent to sot_red_alert\n"; #debug
+    print FILE "This message sent to malgosia\n"; #debug
     close FILE;
 
-    open MAIL, "|mailx -s AACCCDPT brad\@head.cfa.harvard.edu";
-    #open MAIL, "|mailx -s AACCCDPT sot_red_alert\@head.cfa.harvard.edu,aspect_help,6177214364\@vtext.com,8572591479\@vtext";
+    open MAIL, "|mailx -s AACCCDPT msobolewska\@cfa.harvard.edu";
+    #open MAIL, "|mailx -s AACCCDPT sot_red_alert\@cfa.harvard.edu,aspect_help,6177214364\@vtext.com,8572591479\@vtext";
     open FILE, $afile;
     while (<FILE>) {
       print MAIL $_;
@@ -1863,8 +1870,8 @@ sub send_ldrtno_alert {
     print FILE "This message sent to sot_red_alert\n"; #debug
     close FILE;
 
-    #open MAIL, "|mailx -s 3LDRTNO brad\@head.cfa.harvard.edu";
-    open MAIL, "|mailx -s 3LDRTNO sot_red_alert\@head.cfa.harvard.edu";
+    #open MAIL, "|mailx -s 3LDRTNO msobolewska\@cfa.harvard.edu";
+    open MAIL, "|mailx -s 3LDRTNO sot_red_alert\@cfa.harvard.edu";
     open FILE, $afile;
     while (<FILE>) {
       print MAIL $_;

--- a/snapshot/tlogr_linux.pl
+++ b/snapshot/tlogr_linux.pl
@@ -86,9 +86,9 @@ if (! $aos) {
   # if no data on primary or backup, send alert
   if (-s $check_comm_file && -s $check_comm_file_bu && ! -s $check_comm_sent && &time_test($check_comm_file,20)) {
     `cp $check_comm_file $check_comm_sent`;
-    #`cat $check_comm_file | mailx -s 'check_comm' malgosia\@head.cfa.harvard.edu swolk\@head.cfa.harvard.edu`;
-    #`cat $check_comm_file | mailx -s 'check_comm' sot_lead\@head.cfa.harvard.edu malgosia\@head.cfa.harvard.edu jnichols\@head.cfa.harvard.edu`;
-    `cat $check_comm_file | mailx -s 'check_comm' malgosia\@head.cfa.harvard.edu swolk\@head.cfa.harvard.edu 6177214360\@vtext.com`;
+    #`cat $check_comm_file | mailx -s 'check_comm' msobolewska\@cfa.harvard.edu swolk\@cfa.harvard.edu`;
+    #`cat $check_comm_file | mailx -s 'check_comm' sot_lead\@cfa.harvard.edu msobolewska\@cfa.harvard.edu jnichols\@cfa.harvard.edu`;
+    `cat $check_comm_file | mailx -s 'check_comm' msobolewska\@cfa.harvard.edu swolk\@cfa.harvard.edu 6177214360\@vtext.com`;
   } # if (-s $check_comm_file && -s $check_comm_file_bu && 
   # give backup control of alerts, in case it sees data
   if (! -e "/home/mta/Snap/.alerts_bu") {
@@ -107,7 +107,7 @@ if (-e "/home/mta/Snap/.alerts_bu") {
 } # if (-e "/home/mta/Snap/.alerts_bu") {
 # start check_comm all clear e-mails
 if (-s $check_comm_file) {
-  open MAIL, "| mailx -s 'check_comm' malgosia\@head.cfa.harvard.edu swolk\@head.cfa.harvard.edu 6177214360\@vtext.com";
+  open MAIL, "| mailx -s 'check_comm' msobolewska\@cfa.harvard.edu swolk\@cfa.harvard.edu 6177214360\@vtext.com";
   print MAIL "Rhodes data flow resumed.\n";
   close MAIL;
   unlink $check_comm_file;
@@ -115,9 +115,9 @@ if (-s $check_comm_file) {
 
 #if (! -s $check_comm_file && ! -s $check_comm_file_bu && -s $check_comm_sent) {
 if (! -s $check_comm_file && -s $check_comm_sent) {
-  #open MAIL, "| mailx -s 'check_comm' malgosia\@head.cfa.harvard.edu swolk\@head.cfa.harvard.edu";
-  #open MAIL, "| mailx -s 'check_comm' sot_lead\@head.cfa.harvard.edu malgosia\@head.cfa.harvard.edu jnichols\@head.cfa.harvard.edu";
-  open MAIL, "| mailx -s 'check_comm' malgosia\@head.cfa.harvard.edu swolk\@head.cfa.harvard.edu 6177214360\@vtext.com";
+  #open MAIL, "| mailx -s 'check_comm' msobolewska\@cfa.harvard.edu swolk\@cfa.harvard.edu";
+  #open MAIL, "| mailx -s 'check_comm' sot_lead\@cfa.harvard.edu msobolewska\@cfa.harvard.edu jnichols\@cfa.harvard.edu";
+  open MAIL, "| mailx -s 'check_comm' msobolewska\@cfa.harvard.edu swolk\@cfa.harvard.edu 6177214360\@vtext.com";
   print MAIL "Real-time data flow has resumed.\n";
   close MAIL;
   unlink $check_comm_sent;

--- a/space_weather/G13_red_viol.pl
+++ b/space_weather/G13_red_viol.pl
@@ -52,9 +52,9 @@ while (<IN>) {
         printf OUT " Value: %6.2f p/cm2-s-sr-MeV\n",$p2;
         printf OUT " Limit: %6.2f \n", $P2_lim;
         close OUT;
-        `cat $p2r_lockfile | mailx -s "GOES Alert Telecon now" sot_red_alert`;
-        #`cat $p2r_lockfile | mailx -s "GOES Alert" sot_red_alert`;
-        #`cat $p2r_lockfile | mailx -s "GOES Alert TEST" brad`;
+        `cat $p2r_lockfile | mailx -s "GOES Alert Telecon now" sot_red_alert\@cfa.harvard.edu`;
+        #`cat $p2r_lockfile | mailx -s "GOES Alert" sot_red_alert\@cfa.harvard.edu`;
+        #`cat $p2r_lockfile | mailx -s "GOES Alert TEST" msobolewska\@cfa.harvard.edu`;
       } # if ($p2_wait == 5) {
     } else { # if (!-s $lockfile) { # if an alert hasn't been sent, send one
       `date >> $p2r_lockfile`;  # touch $lockfile
@@ -73,8 +73,8 @@ while (<IN>) {
         printf OUT " Value: %6.2f p/cm2-s-sr-MeV\n",$p5;
         printf OUT " Limit: %6.2f \n", $P5_lim;
         close OUT;
-        `cat $p5r_lockfile | mailx -s "GOES Alert Telecon now" sot_red_alert`;
-        #`cat $p5r_lockfile | mailx -s "GOES Alert TEST" brad`;
+        `cat $p5r_lockfile | mailx -s "GOES Alert Telecon now" sot_red_alert\@cfa.harvard.edu`;
+        #`cat $p5r_lockfile | mailx -s "GOES Alert TEST" msobolewska\@cfa.harvard.edu`;
       } # if ($p5_wait == 5) {
     } else { # if (!-s $lockfile) { # if an alert hasn't been sent, send one
       `date >> $p5r_lockfile`;  # touch $lockfile

--- a/space_weather/G13_yellow_viol.pl
+++ b/space_weather/G13_yellow_viol.pl
@@ -51,8 +51,8 @@ while (<IN>) {
         printf OUT " Value: %6.2f p/cm2-s-sr-MeV\n",$p2;
         printf OUT " Limit: %6.2f\n", $P2_lim;
         close OUT;
-        `cat $p2y_lockfile | mailx -s "GOES Alert" sot_ace_alert sot_yellow_alert sot_ace_alert 6172573986\@mobile.mycingular.com`;
-        #`cat $p2y_lockfile | mailx -s "GOES Alert TEST" brad`;
+        `cat $p2y_lockfile | mailx -s "GOES Alert" sot_ace_alert\@cfa.harvard.edu sot_yellow_alert\@cfa.harvard.edu 6172573986\@mobile.mycingular.com`;
+        #`cat $p2y_lockfile | mailx -s "GOES Alert TEST" msobolewska\@cfa.harvard.edu`;
       } # if ($p2_wait == 5) {
     } else { # if (!-s $lockfile) { # if an alert hasn't been sent, send one
       `date >> $p2y_lockfile`;  # touch $lockfile
@@ -70,8 +70,8 @@ while (<IN>) {
         printf OUT " Value: %6.2f p/cm2-s-sr-MeV\n",$p5;
         printf OUT " Limit: %6.2f\n", $P5_lim;
         close OUT;
-        `cat $p5y_lockfile | mailx -s "GOES Alert" sot_ace_alert sot_yellow_alert 6172573986\@mobile.mycingular.com`;
-        #`cat $p5y_lockfile | mailx -s "GOES Alert TEST" brad`;
+        `cat $p5y_lockfile | mailx -s "GOES Alert" sot_ace_alert\@cfa.harvard.edu sot_yellow_alert\@cfa.harvard.edu 6172573986\@mobile.mycingular.com`;
+        #`cat $p5y_lockfile | mailx -s "GOES Alert TEST" msobolewska\@cfa.harvard.edu`;
       } # if ($p5_wait == 5) {
     } else { # if (!-s $lockfile) { # if an alert hasn't been sent, send one
       `date >> $p5y_lockfile`;  # touch $lockfile

--- a/space_weather/G15_red_viol.pl
+++ b/space_weather/G15_red_viol.pl
@@ -52,8 +52,8 @@ while (<IN>) {
         printf OUT " Value: %6.2f p/cm2-s-sr-MeV\n",$p2;
         printf OUT " Limit: %6.2f (temp limit for test)\n", $P2_lim;
         close OUT;
-        #`cat $p2r_lockfile | mailx -s "GOES Alert Telecon now" sot_red_alert`;
-        `cat $p2r_lockfile | mailx -s "GOES Alert TEST" brad`;
+        #`cat $p2r_lockfile | mailx -s "GOES Alert Telecon now" sot_red_alert\@cfa.harvard.edu`;
+        `cat $p2r_lockfile | mailx -s "GOES Alert TEST" msobolewska\@cfa.harvard.edu`;
       } # if ($p2_wait == 5) {
     } else { # if (!-s $lockfile) { # if an alert hasn't been sent, send one
       `date >> $p2r_lockfile`;  # touch $lockfile
@@ -72,8 +72,8 @@ while (<IN>) {
         printf OUT " Value: %6.2f p/cm2-s-sr-MeV\n",$p5;
         printf OUT " Limit: %6.2f (temp limit for test)\n", $P5_lim;
         close OUT;
-        #`cat $p5r_lockfile | mailx -s "GOES Alert Telecon now" sot_red_alert`;
-        `cat $p5r_lockfile | mailx -s "GOES Alert TEST" brad`;
+        #`cat $p5r_lockfile | mailx -s "GOES Alert Telecon now" sot_red_alert\@cfa.harvard.edu`;
+        `cat $p5r_lockfile | mailx -s "GOES Alert TEST" msobolewska\@cfa.harvard.edu`;
       } # if ($p5_wait == 5) {
     } else { # if (!-s $lockfile) { # if an alert hasn't been sent, send one
       `date >> $p5r_lockfile`;  # touch $lockfile

--- a/space_weather/G15_yellow_viol.pl
+++ b/space_weather/G15_yellow_viol.pl
@@ -51,8 +51,8 @@ while (<IN>) {
         printf OUT " Value: %6.2f p/cm2-s-sr-MeV\n",$p2;
         printf OUT " Limit: %6.2f\n", $P2_lim;
         close OUT;
-        #`cat $p2y_lockfile | mailx -s "GOES Alert" sot_yellow_alert 6172573986\@mobile.mycingular.com`;
-        `cat $p2y_lockfile | mailx -s "GOES Alert TEST" brad`;
+        #`cat $p2y_lockfile | mailx -s "GOES Alert" sot_yellow_alert\@cfa.harvard.edu 6172573986\@mobile.mycingular.com`;
+        `cat $p2y_lockfile | mailx -s "GOES Alert TEST" msobolewska\@cfa.harvard.edu`;
       } # if ($p2_wait == 5) {
     } else { # if (!-s $lockfile) { # if an alert hasn't been sent, send one
       `date >> $p2y_lockfile`;  # touch $lockfile
@@ -70,8 +70,8 @@ while (<IN>) {
         printf OUT " Value: %6.2f p/cm2-s-sr-MeV\n",$p5;
         printf OUT " Limit: %6.2f\n", $P5_lim;
         close OUT;
-        #`cat $p5y_lockfile | mailx -s "GOES Alert" sot_yellow_alert 6172573986\@mobile.mycingular.com`;
-        `cat $p5y_lockfile | mailx -s "GOES Alert TEST" brad`;
+        #`cat $p5y_lockfile | mailx -s "GOES Alert" sot_yellow_alert\@cfa.harvard.edu 6172573986\@mobile.mycingular.com`;
+        `cat $p5y_lockfile | mailx -s "GOES Alert TEST" msobolewska\@cfa.harvard.edu`;
       } # if ($p5_wait == 5) {
     } else { # if (!-s $lockfile) { # if an alert hasn't been sent, send one
       `date >> $p5y_lockfile`;  # touch $lockfile

--- a/space_weather/ace_12h_viol.pl
+++ b/space_weather/ace_12h_viol.pl
@@ -37,8 +37,8 @@ if (($hour_now < 24.) && ($hour_now > 7.)) {
             print OUT "Radiation team should investigate\n";
             print OUT "This message sent to sot_ace_alert\n";
             close OUT;
-            `cat $lockfile | mailx -s "ACE no valid data for >12h" sot_ace_alert`;
-            # `cat $lockfile | mailx -s "ACE no valid data for >12h" malgosia swolk`;
+            `cat $lockfile | mailx -s "ACE no valid data for >12h" sot_ace_alert\@cfa.harvard.edu`;
+            # `cat $lockfile | mailx -s "ACE no valid data for >12h" msobolewska\@cfa.harvard.edu swolk\@cfa.harvard.edu`;
             # Store the 12h archive that triggered the alert
             `cp $infile "$lockdir/ace_12h_archive_alert"`;
         }

--- a/space_weather/ace_invalid_spec.csh
+++ b/space_weather/ace_invalid_spec.csh
@@ -16,8 +16,8 @@ set lock = "/pool1/mta/prot_spec_violate"
       echo "see http://cxc.harvard.edu/mta/ace.html" >> $lock
 
       echo "This message sent to sot_yellow_alert" >> $lock
-      cat $lock | mailx -s ACE_p5/p6 sot_yellow_alert
-      #cat $lock | mailx -s ACE_p5/p6 brad swolk
+      cat $lock | mailx -s ACE_p5/p6 sot_yellow_alert@cfa.harvard.edu
+      #cat $lock | mailx -s ACE_p5/p6 swolk@cfa.harvard.edu
     endif
 
 #end

--- a/space_weather/aceviolation_protons.csh
+++ b/space_weather/aceviolation_protons.csh
@@ -37,15 +37,15 @@ set block = "/data/mta4/www/Snapshot/.scs107alert"
         echo "The ACIS on-call person should review the data and call a telecon if necessary. " >> $lock
         echo "This message sent to sot_ace_alert" >> $lock
         #cat $lock | mailx -s "ACE_p3 telecon now" sot_red_alert
-        #cat $lock | mailx -s "ACE_p3 " sot_red_alert
-        cat $lock | mailx -s "ACE_p3 " sot_ace_alert
+        #cat $lock | mailx -s "ACE_p3 " sot_red_alert@cfa.harvard.edu
+        cat $lock | mailx -s "ACE_p3 " sot_ace_alert@cfa.harvard.edu
         #cat $lock | mailx -s "ACE_p3 telecon now" 6172573986@mobile.mycingular.com
       endif
       if ( -s $block) then
         echo "This message sent to sot_yellow_alert" >> $lock
-        cat $lock | mailx -s ACE_p3 sot_yellow_alert
+        cat $lock | mailx -s ACE_p3 sot_yellow_alert@cfa.harvard.edu
       endif
-      #cat $lock | mailx -s ACE_p3_test brad 
+      #cat $lock | mailx -s ACE_p3_test msobolewska@cfa.harvard.edu 
     endif
 
 #end

--- a/space_weather/aceviolation_protonsP3_P5.csh
+++ b/space_weather/aceviolation_protonsP3_P5.csh
@@ -33,16 +33,16 @@ set block = "/home/mta/Snap/.scs107alert"
 
       if (! -s $block) then
         #echo "This message sent to sot_yellow_alert" >> $lock
-        #cat $lock | mailx -s ACE_p3_scaled sot_yellow_alert
-        cat $lock | mailx -s ACE_p3_scaled brad
+        #cat $lock | mailx -s ACE_p3_scaled sot_yellow_alert@cfa.harvard.edu
+        cat $lock | mailx -s ACE_p3_scaled msobolewska@cfa.harvard.edu
       endif
       if ( -s $block) then
         #echo "This message sent to sot_yellow_alert" >> $lock
-        #cat $lock | mailx -s ACE_p3_scaled sot_yellow_alert
-        cat $lock | mailx -s ACE_p3_scaled brad
+        #cat $lock | mailx -s ACE_p3_scaled sot_yellow_alert@cfa.harvard.edu
+        cat $lock | mailx -s ACE_p3_scaled msobolewska@cfa.harvard.edu
       endif
 
-      #cat $lock | mailx -s ACE_p3_test brad 
+      #cat $lock | mailx -s ACE_p3_test msobolewska@cfa.harvard.edu
     endif
 
 #end

--- a/space_weather/aceviolation_protonsP6.csh
+++ b/space_weather/aceviolation_protonsP6.csh
@@ -34,15 +34,15 @@ set block = "/home/mta/Snap/.scs107alert"
 
       if (! -s $block) then
         #echo "This message sent to sot_yellow_alert" >> $lock
-        #cat $lock | mailx -s ACE_p3_scaled sot_yellow_alert
-        cat $lock | mailx -s ACE_p3_scaled brad
+        #cat $lock | mailx -s ACE_p3_scaled sot_yellow_alert@cfa.harvard.edu
+        cat $lock | mailx -s ACE_p3_scaled msobolewska@cfa.harvard.edu
       endif
       if ( -s $block) then
         #echo "This message sent to sot_yellow_alert" >> $lock
-        #cat $lock | mailx -s ACE_p3_scaled sot_yellow_alert
-        cat $lock | mailx -s ACE_p3_scaled brad
+        #cat $lock | mailx -s ACE_p3_scaled sot_yellow_alert@cfa.harvard.edu
+        cat $lock | mailx -s ACE_p3_scaled msobolewska@cfa.harvard.edu
       endif
-      #cat $lock | mailx -s ACE_p3_scaled brad
+      #cat $lock | mailx -s ACE_p3_scaled msobolewska@cfa.harvard.edu
 
     endif
 

--- a/space_weather/goes_hrc_proxy_viol.pl
+++ b/space_weather/goes_hrc_proxy_viol.pl
@@ -30,7 +30,7 @@ while (<IN>) {
             print OUT "see http://cxc.cfa.harvard.edu/mta/G13.html\n";
             print OUT "This message sent to sot_ace_alert\n";
             close OUT;
-            `cat $lockfile | mailx -s "GOES HRC proxy" sot_ace_alert`;
+            `cat $lockfile | mailx -s "GOES HRC proxy" sot_ace_alert\@cfa.harvard.edu`;
         }
     }
 }


### PR DESCRIPTION
This branch contains updates to the MTA email alerts related to
- primary snapshot/alerting script (c3po-v;  tlogr_linux.pl, check_state.pm),
- mirror snapshot/alerting script (colossus-v, check_state_alerts.pm, check_state_noalerts.pm) ,
- acorn monitor on c3po-v (primary) and colossus-v (mirror),
- space weather related scripts
- dumps monitor script.

The updates are needed following the migration from majordomo to google groups, and downtime of the HEA/CXC server room at Garden St on Wednesday, 8/1/2018.

The alerts_install.sh script will be used to copy the updated scripts to their flight locations.
